### PR TITLE
Check also if obj is not None

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -117,6 +117,8 @@ def fetch_callback(message_data,message):
 
         try:
             obj = HarvestObject.get(id)
+            if obj is None:
+                raise Exception
         except:
             log.error('Harvest object does not exist: %s' % id)
         else:


### PR DESCRIPTION
We encountered this issue when restoring a database backup. At that moment the database had different data than the harvest object queue and the whole fetch_consumer failed because obj.source raised an exception (as obj was None).

This little fix solves the problem on 1.8, I don't know if also the 2.0 is affected.