### PR TITLE
[#62] Use current name when updating package, if the user haven't sent a...

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -166,6 +166,8 @@ class HarvesterBase(SingletonPlugin):
                     log.info('Package with GUID %s exists and needs to be updated' % harvest_object.guid)
                     # Update package
                     context.update({'id':package_dict['id']})
+                    package_dict.setdefault('name',
+                            existing_package_dict['name'])
                     new_package = get_action('package_update_rest')(context, package_dict)
 
                 else:


### PR DESCRIPTION
... new one

It's hard for someone outside CKAN to make sure they're sending it in the format
we expect. And they'll also have to keep track of our name format, to keep in
sync whenever we change.

To fix this, we simply do what we already do when creating packages: use a
default name. In this case, the current one.
