### PR TITLE
add deletion to ckanharvester for harvesting < 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,6 +200,12 @@ field. The currently supported configuration options are:
     present in the local CKAN. Setting it to 'create' will make an attempt to
     create the groups by copying the details from the remote CKAN.
 
+*   manage_deletions: By default, if a package is deleted on a remote site and
+    the remote site is a version of CKAN before 2.0. The package will not be
+    deleted when harvested. Setting this will delete any packages that are not
+    on the remote site. For remote sites running a version greater than CKAN 2.0
+    the packages will be deleted by default.
+
 Here is an example of a configuration object (the one that must be entered in
 the configuration field)::
 

--- a/README.rst
+++ b/README.rst
@@ -203,8 +203,9 @@ field. The currently supported configuration options are:
 *   manage_deletions: By default, if a package is deleted on a remote site and
     the remote site is a version of CKAN before 2.0. The package will not be
     deleted when harvested. Setting this will delete any packages that are not
-    on the remote site. For remote sites running a version greater than CKAN 2.0
-    the packages will be deleted by default.
+    on the remote site package list. For remote sites running a version greater
+    than CKAN 2.0 the packages will be deleted by default and there is no need to
+    set this option.
 
 Here is an example of a configuration object (the one that must be entered in
 the configuration field)::

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -239,18 +239,15 @@ class HarvesterBase(SingletonPlugin):
         }
 
         try:
-            harvest_object.current = False
-            get_action('package_delete')(context, {'id': harvest_object.guid})
+            get_action('package_delete')(context, {'id': harvest_object.package_id})
             log.info('Deleted package with guid {0}'.format(
                 harvest_object.guid))
-        except ActionError, e:
+            Session.query(HarvestObject).\
+                    filter_by(guid=harvest_object.guid).\
+                    update({'current': False}, False)
+            Session.commit()
+            return True
+        except Exception, e:
             log.exception(e)
             self._save_object_error('%r'%e, harvest_object, 'Import')
-        
-
-        previous_harvest = Session.query(HarvestObject) \
-                          .filter(HarvestObject.guid==harvest_object.guid) \
-                          .filter(HarvestObject.current==True) \
-                          .first()
-        previous_harvest.current = False
-        previous_harvest.save()
+            return False

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -240,9 +240,9 @@ class HarvesterBase(SingletonPlugin):
 
         try:
             harvest_object.current = False
-            get_action('package_delete')(context, {'id': harvest_object.package_id})
-            log.info('Deleted package {0} with guid {1}'.format(
-                harvest_object.package_id, harvest_object.guid))
+            get_action('package_delete')(context, {'id': harvest_object.guid})
+            log.info('Deleted package with guid {0}'.format(
+                harvest_object.guid))
         except ActionError, e:
             log.exception(e)
             self._save_object_error('%r'%e, harvest_object, 'Import')

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -145,7 +145,7 @@ class CKANHarvester(HarvesterBase):
         for package_id in deleted_ids:
             harvest_object = HarvestObject(job=harvest_job,
                 extras=[HarvestObjectExtra(key='status', value=DELETE)],
-                guid=package_id
+                package_id=package_id
             )
             harvest_object.save()
             deleted.append(harvest_object.id)

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -288,12 +288,7 @@ class CKANHarvester(HarvesterBase):
         self._set_config(harvest_object.job.source.config)
 
         if harvest_object.content == DELETE:
-            try:
-                self._delete_package(harvest_object)
-            except Exception, e:
-                self._save_object_error('%r'%e,harvest_object,'Import')
-                return False
-            return True
+            return self._delete_package(harvest_object)
 
         try:
             package_dict = json.loads(harvest_object.content)

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -40,7 +40,7 @@ class CKANHarvester(HarvesterBase):
             http_request.add_header('Authorization',api_key)
         http_response = urllib2.urlopen(http_request)
 
-        return http_response.read().decode('utf-8')
+        return http_response.read()
 
     def _get_group(self, base_url, group_name):
         url = base_url + self._get_rest_api_offset() + '/group/' + group_name
@@ -109,7 +109,7 @@ class CKANHarvester(HarvesterBase):
                 except NotFound,e:
                     raise ValueError('User not found')
 
-            for key in ('read_only','force_all'):
+            for key in ('read_only','force_all', 'manage_deletions'):
                 if key in config_obj:
                     if not isinstance(config_obj[key],bool):
                         raise ValueError('%s must be boolean' % key)
@@ -223,7 +223,7 @@ class CKANHarvester(HarvesterBase):
 
         try:
             object_ids = []
-            if int(self.config['api_version']) < 3:
+            if self.config.get('manage_deletions', False):
                 missing_ids = self._get_deleted_packages(base_rest_url + '/package', harvest_job)
                 if missing_ids:
                     object_ids.extend(missing_ids)
@@ -254,7 +254,7 @@ class CKANHarvester(HarvesterBase):
         for extra in harvest_object.extras:
             if extra.key == 'status' and extra.value == DELETE:
                 harvest_object.content = DELETE
-                harvest_object.package_id = harvest_object.guid
+                harvest_object.save()
                 return True
 
         # Get source URL


### PR DESCRIPTION
maybe this should be a config option as well

Prior to 2.0, https://github.com/okfn/ckan/pull/545 the api returns a 403 error. Deletions will appear in the list of revisions in the gather stage but will error during the import stage.