### PR TITLE
[#61] Truly ignore harvest sources

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -247,7 +247,7 @@ class CKANHarvester(HarvesterBase):
 
             if package_dict.get('type') == 'harvest':
                 log.warn('Remote dataset is a harvest source, ignoring...')
-                return False
+                return True
 
             # Set default tags if needed
             default_tags = self.config.get('default_tags',[])


### PR DESCRIPTION
The currently implementation returns False when a harvest source is being harvested. This leads to an error on the harvesting job, which in turn tends to confuse users that have no idea of this special implementation. This fix ensures that harvest sources are still ignored, but silently.
