### PR TITLE
Wrap tag munging code in config option, defaulting to False.

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -35,7 +35,6 @@ def munge_tag(tag):
         return tag
 
 
-
 class HarvesterBase(SingletonPlugin):
     '''
     Generic class for  harvesters with helper functions


### PR DESCRIPTION
If the config option 'ckanext.harvest.ckanharvester.clean_tags' is set to True, tags will be stripped of accent characters and capital letters for display. If it is not set or set to False, tags will be imported as they appear on the remote server. Fixes issue #79.
