### PR TITLE
Harvesting and DataPusher incompatibility

### DIFF
--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -145,6 +145,16 @@ class Harvester(CkanCommand):
 
     def _load_config(self):
         super(Harvester, self)._load_config()
+        import pylons
+        c = pylons.util.AttribSafeContextObj()
+
+        self.registry.register(pylons.c, c)
+
+        self.site_user = get_action('get_site_user')({'ignore_auth': True}, {})
+
+        pylons.c.user = self.site_user['name']
+        pylons.c.userobj = model.User.get(self.site_user['name'])
+
 
     def initdb(self):
         from ckanext.harvest.model import setup as db_setup


### PR DESCRIPTION
When running a harvester with the DataPusher extension enabled an exception is raised when the DataPusher tries to get information from the user which is coming from the web request. Harvesters are run from the command line, so there is no web request available.

```
  File "/usr/lib/ckan/default/src/ckan/ckan/model/modification.py", line 79, in notify
    observer.notify(entity, operation)
  File "/usr/lib/ckan/default/src/ckan/ckanext/datapusher/plugin.py", line 103, in notify
    'resource_id': entity.id
  File "/usr/lib/ckan/default/src/ckan/ckan/logic/__init__.py", line 419, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/default/src/ckan/ckanext/datapusher/logic/action.py", line 51, in datapusher_submit
    user = p.toolkit.get_action('user_show')(context, {'id': context['user']})
KeyError: 'user'
```
We can try and mimic a web request with the site_user on the command script.

This is not limited to the harvesting extension, any script creating / updating datasets running from the command line will have this problem. See  ckan/ckan#1500