### PR TITLE
Job reporting fixes

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -178,8 +178,6 @@ class HarvesterBase(SingletonPlugin):
 
                 else:
                     log.info('Package with GUID %s not updated, skipping...' % harvest_object.guid)
-                    harvest_object.report_status = 'not modified'
-                    harvest_object.save()
                     return
 
                 # Flag the other objects linking to this package as not current anymore

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -178,6 +178,8 @@ class HarvesterBase(SingletonPlugin):
 
                 else:
                     log.info('Package with GUID %s not updated, skipping...' % harvest_object.guid)
+                    harvest_object.report_status = 'not modified'
+                    harvest_object.save()
                     return
 
                 # Flag the other objects linking to this package as not current anymore

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -378,6 +378,17 @@ class CKANHarvester(HarvesterBase):
             for resource in package_dict.get('resources', []):
                 resource.pop('url_type', None)
 
+            # Check if package exists
+            data_dict = {}
+            data_dict['id'] = package_dict['id']
+            try:
+                existing_package_dict = get_action('package_show')(context, data_dict)
+                if 'metadata_modified' in package_dict and \
+                                package_dict['metadata_modified'] <= existing_package_dict.get('metadata_modified'):
+                    return "unchanged"
+            except NotFound:
+                pass
+
             result = self._create_or_update_package(package_dict,harvest_object)
 
             if result and self.config.get('read_only',False) == True:

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -165,7 +165,7 @@ class CKANHarvester(HarvesterBase):
                                     package_ids.append(package_id)
                     else:
                         log.info('No packages have been updated on the remote CKAN instance since the last harvest job')
-                        return None
+                        return []
 
                 except urllib2.HTTPError,e:
                     if e.getcode() == 400:

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -318,7 +318,7 @@ def harvest_jobs_run(context,data_dict):
                     if last_object:
                         job_obj.finished = last_object.import_finished
                     else:
-                        job.obj.finished = job['gather_finished']
+                        job_obj.finished = job['gather_finished']
                     job_obj.save()
                     # Reindex the harvest source dataset so it has the latest
                     # status

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -317,6 +317,8 @@ def harvest_jobs_run(context,data_dict):
                           .first()
                     if last_object:
                         job_obj.finished = last_object.import_finished
+                    else:
+                        job.obj.finished = job['gather_finished']
                     job_obj.save()
                     # Reindex the harvest source dataset so it has the latest
                     # status

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -318,7 +318,7 @@ def fetch_and_import_stages(harvester, obj):
     else:
         obj.state = "ERROR"
         obj.save()
-    if obj.report_status:
+    if obj.report_status == 'not modified':
         return
     if obj.state == 'ERROR':
         obj.report_status = 'errored'

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -312,14 +312,16 @@ def fetch_and_import_stages(harvester, obj):
         obj.import_finished = datetime.datetime.utcnow()
         if success_import:
             obj.state = "COMPLETE"
+            if success_import is 'unchanged':
+                obj.report_status = 'not modified'
+                obj.save()
+                return
         else:
             obj.state = "ERROR"
         obj.save()
     else:
         obj.state = "ERROR"
         obj.save()
-    if obj.report_status == 'not modified':
-        return
     if obj.state == 'ERROR':
         obj.report_status = 'errored'
     elif obj.current == False:


### PR DESCRIPTION
Job reporting has some inconsistencies which causes confusing behavior. 

If harvest job is executed and there are zero new revision, the harvest job never receives job finished timestamp.

If harvest job is executed again, it refresher all harvested datasets, but since it creates new HarvestObjects, they don't have report_status saved and the job report shows that all datasets are deleted although nothing actually changed.