### PR TITLE
Make sure new packages get a unique 'name'

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -202,7 +202,7 @@ class HarvesterBase(SingletonPlugin):
                 context.pop('__auth_audit', None)
 
                 # Set name for new package to prevent name conflict, see issue #117
-                if ('name' in package_dict and not package_dict['name']):
+                if package_dict.get('name', None):
                     package_dict['name'] = self._gen_new_name(package_dict['name'])
                 else:
                     package_dict['name'] = self._gen_new_name(package_dict['title'])

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -201,8 +201,11 @@ class HarvesterBase(SingletonPlugin):
                 # exception
                 context.pop('__auth_audit', None)
 
-                # Set name if not already there
-                package_dict.setdefault('name', self._gen_new_name(package_dict['title']))
+                # Set name for new package to prevent name conflict, see issue #117
+                if ('name' in package_dict and not package_dict['name']):
+                    package_dict['name'] = self._gen_new_name(package_dict['name'])
+                else:
+                    package_dict['name'] = self._gen_new_name(package_dict['title'])
 
                 log.info('Package with GUID %s does not exist, let\'s create it' % harvest_object.guid)
                 harvest_object.current = True


### PR DESCRIPTION
This fixes #117.

The problem is that a "new" package could have a 'name' attributes that's already taken. By using `gen_new_name()` we can be sure the name is valid for this instance. The conditional is only there to ensure that the existing 'name' is used if possible, but maybe that's not even necessary.