### PR TITLE
Fetch remote organization via action api

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -5,6 +5,7 @@ from ckan import model
 from ckan.model import Session, Package
 from ckan.logic import ValidationError, NotFound, get_action
 from ckan.lib.helpers import json
+from ckan.lib.munge import munge_name
 
 from ckanext.harvest.model import HarvestJob, HarvestObject, HarvestGatherError, \
                                     HarvestObjectError
@@ -51,7 +52,7 @@ class CKANHarvester(HarvesterBase):
         return http_response.read()
 
     def _get_group(self, base_url, group_name):
-        url = base_url + self._get_rest_api_offset() + '/group/' + group_name
+        url = base_url + self._get_rest_api_offset() + '/group/' + munge_name(group_name)
         try:
             content = self._get_content(url)
             return json.loads(content)

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -47,7 +47,7 @@ class CKANHarvester(HarvesterBase):
         except urllib2.URLError, e:
             raise ContentFetchError(
                 'Could not fetch url: %s, error: %s' % 
-                (url, e.reason)
+                (url, str(e))
             )
         return http_response.read()
 

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -44,10 +44,10 @@ class CKANHarvester(HarvesterBase):
 
         try:
             http_response = urllib2.urlopen(http_request)
-        except urllib2.HTTPError, e:
+        except urllib2.URLError, e:
             raise ContentFetchError(
-                'Could not fetch url: %s, HTTP error code: %s' % 
-                (url, e.code)
+                'Could not fetch url: %s, error: %s' % 
+                (url, e.reason)
             )
         return http_response.read()
 

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -337,7 +337,14 @@ class CKANHarvester(HarvesterBase):
                         log.info('Organization %s is not available' % remote_org)
                         if remote_orgs == 'create':
                             try:
-                                org = self._get_organization(harvest_object.source.url, remote_org)
+                                try:
+                                    org = self._get_organization(harvest_object.source.url, remote_org)
+                                except:
+                                    # fallback if remote CKAN exposes organizations as groups
+                                    # this especially targets older versions of CKAN
+                                    log.debug('_get_organization() failed, now trying _get_group()')
+                                    org = self._get_group(harvest_object.source.url, remote_org)
+
                                 for key in ['packages', 'created', 'users', 'groups', 'tags', 'extras', 'display_name', 'type']:
                                     org.pop(key, None)
                                 get_action('organization_create')(context, org)

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -177,7 +177,7 @@ class CKANHarvester(HarvesterBase):
                             url = base_rest_url + '/revision/%s' % revision_id
                             try:
                                 content = self._get_content(url)
-                            except Exception,e:
+                            except ContentFetchError,e:
                                 self._save_gather_error('Unable to get content for URL: %s: %s' % (url, str(e)),harvest_job)
                                 continue
 
@@ -204,7 +204,7 @@ class CKANHarvester(HarvesterBase):
             url = base_rest_url + '/package'
             try:
                 content = self._get_content(url)
-            except Exception,e:
+            except ContentFetchError,e:
                 self._save_gather_error('Unable to get content for URL: %s: %s' % (url, str(e)),harvest_job)
                 return None
 
@@ -241,7 +241,7 @@ class CKANHarvester(HarvesterBase):
         # Get contents
         try:
             content = self._get_content(url)
-        except Exception,e:
+        except ContentFetchError,e:
             self._save_object_error('Unable to get content for package: %s: %r' % \
                                         (url, e),harvest_object)
             return None

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -21,9 +21,13 @@ class CKANHarvester(HarvesterBase):
     config = None
 
     api_version = 2
+    action_api_version = 3
 
     def _get_rest_api_offset(self):
         return '/api/%d/rest' % self.api_version
+
+    def _get_action_api_offset(self):
+        return '/api/%d/action' % self.action_api_version
 
     def _get_search_api_offset(self):
         return '/api/%d/search' % self.api_version
@@ -45,6 +49,15 @@ class CKANHarvester(HarvesterBase):
         try:
             content = self._get_content(url)
             return json.loads(content)
+        except Exception, e:
+            raise e
+
+    def _get_organization(self, base_url, org_name):
+        url = base_url + self._get_action_api_offset() + '/organization_show?id=' + org_name
+        try:
+            content = self._get_content(url)
+            content_dict = json.loads(content)
+            return content_dict['result']
         except Exception, e:
             raise e
 
@@ -324,7 +337,7 @@ class CKANHarvester(HarvesterBase):
                         log.info('Organization %s is not available' % remote_org)
                         if remote_orgs == 'create':
                             try:
-                                org = self._get_group(harvest_object.source.url, remote_org)
+                                org = self._get_organization(harvest_object.source.url, remote_org)
                                 for key in ['packages', 'created', 'users', 'groups', 'tags', 'extras', 'display_name', 'type']:
                                     org.pop(key, None)
                                 get_action('organization_create')(context, org)


### PR DESCRIPTION
Organizations used to be returned by `/api/2/rest/group`, this is what the
old implementation used to fetch the information to create the remote
organization on the local instance of CKAN.

With this commit the Action API is used to fetch the same information.

Fixes #120