### PR TITLE
Use the organization slug to get remote org

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -330,12 +330,13 @@ class CKANHarvester(HarvesterBase):
                 # Assign dataset to the source organization
                 package_dict['owner_org'] = local_org
             else:
-                if not 'owner_org' in package_dict:
-                    package_dict['owner_org'] = None
-
                 # check if remote org exist locally, otherwise remove
                 validated_org = None
-                remote_org = package_dict['owner_org']
+                try:
+                    remote_org = package_dict['organization']['name']
+                except KeyError:
+                    log.info('Information about remote organization missing')
+                    remote_org = None
 
                 if remote_org:
                     try:


### PR DESCRIPTION
The API action organization_show does currently not respond to calls
using the GUID of an organization, therefore the slug name has to be
used. It is available in the package_dict and can be used for the call
to the remote API.

Fixes #122 