### PR TITLE
 [WIP] [#138] Add data attributes to support timezone conversion

### DIFF
--- a/ckanext/harvest/templates_new/snippets/job_details.html
+++ b/ckanext/harvest/templates_new/snippets/job_details.html
@@ -50,15 +50,27 @@ Example:
   </tr>
   <tr>
     <th>{{ _('Created') }}</th>
-    <td>{{ h.render_datetime(job.created, with_hours=True) }}</td>
+    <td>
+        <span class="datetime" data-datetime="{{ h.render_datetime(job.created, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+            {{ h.render_datetime(job.created, with_hours=True) }}
+        </span>
+    </td>
   </tr>
   <tr>
     <th>{{ _('Started') }}</th>
-    <td>{{ h.render_datetime(job.gather_started, with_hours=True) }}</td>
+    <td>
+        <span class="datetime" data-datetime="{{ h.render_datetime(job.gather_started, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+            {{ h.render_datetime(job.gather_started, with_hours=True) }}
+        </span>
+    </td>
   </tr>
   <tr>
     <th>{{ _('Finished') }}</th>
-    <td>{{ h.render_datetime(job.finished, with_hours=True) }}</td>
+    <td>
+        <span class="datetime" data-datetime="{{ h.render_datetime(job.finished, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+            {{ h.render_datetime(job.finished, with_hours=True) }}
+        </span>
+    </td>
   </tr>
   <tr>
     <th>{{ _('Status') }}</th>

--- a/ckanext/harvest/templates_new/source/job/list.html
+++ b/ckanext/harvest/templates_new/source/job/list.html
@@ -25,9 +25,15 @@
               {% endif %}
             </h3>
             <p>
-              {{ _('Started:') }} {{ h.render_datetime(job.gather_started, with_hours=True) or _('Not yet') }}
+              {{ _('Started:') }}
+              <span class="datetime" data-datetime="{{ h.render_datetime(job.gather_started, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+                {{ h.render_datetime(job.gather_started, with_hours=True) or _('Not yet') }}
+              </span>
               &mdash;
-              {{ _('Finished:') }} {{ h.render_datetime(job.finished, with_hours=True) or _('Not yet') }}
+              {{ _('Finished:') }}
+              <span class="datetime" data-datetime="{{ h.render_datetime(job.finished, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+                {{ h.render_datetime(job.finished, with_hours=True) or _('Not yet') }}
+              </span>
             </p>
           </div>
           {% if job.status == 'Finished' %}


### PR DESCRIPTION
This PR is based on PR https://github.com/ckan/ckan/pull/2505 and fixes issue #138.

It uses data attributes to embed ISO-formatted dates, which then in turn can be converted to the correct timezone of the user visiting the page.