### PR TITLE
An extension point to allow filtering packages during harvesting

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -273,6 +273,9 @@ class CKANHarvester(HarvesterBase):
                 log.warn('Remote dataset is a harvest source, ignoring...')
                 return True
 
+            if not self._should_import(package_dict):
+                package_dict['state'] = 'deleted'
+
             # Set default tags if needed
             default_tags = self.config.get('default_tags',[])
             if default_tags:
@@ -433,6 +436,11 @@ class CKANHarvester(HarvesterBase):
                     harvest_object, 'Import')
         except Exception, e:
             self._save_object_error('%r'%e,harvest_object,'Import')
+
+    def _should_import(self,package_dict):
+        # Override in harvesters that inherit from CKANHarvester to avoid importing unwanted packages.
+        # Overriding classes should do their own logging of the reason the package is not imported.
+        return True
 
 class ContentFetchError(Exception):
     pass


### PR DESCRIPTION
This allows others to create customized CKAN harvester to exclude packages using any metadata element as criteria. To use this extension point, one just needs to create a new plugin class that inherits from `CKANHarvester` and overrides the `info()` and `_should_import()` methods.