### PR TITLE
[#145] Throw + catch a custom exception if there are no jobs to run

### DIFF
--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -3,6 +3,7 @@ from pprint import pprint
 
 from ckan import model
 from ckan.logic import get_action, ValidationError
+from ckanext.harvest.logic import NoNewHarvestJobError
 
 from ckan.lib.cli import CkanCommand
 
@@ -301,9 +302,10 @@ class Harvester(CkanCommand):
 
     def run_harvester(self):
         context = {'model': model, 'user': self.admin_user['name'], 'session':model.Session}
-        jobs = get_action('harvest_jobs_run')(context,{})
-
-        #print 'Sent %s jobs to the gather queue' % len(jobs)
+        try:
+            jobs = get_action('harvest_jobs_run')(context,{})
+        except NoNewHarvestJobError:
+            print 'There are no new harvest jobs to run.'
 
     def import_stage(self):
 

--- a/ckanext/harvest/logic/__init__.py
+++ b/ckanext/harvest/logic/__init__.py
@@ -7,3 +7,7 @@ except ImportError:
 
 class HarvestJobExists(Exception):
     pass
+
+
+class NoNewHarvestJobError(Exception):
+    pass

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -26,7 +26,7 @@ from ckanext.harvest.plugin import DATASET_TYPE_NAME
 from ckanext.harvest.queue import get_gather_publisher, resubmit_jobs
 
 from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
-from ckanext.harvest.logic import HarvestJobExists
+from ckanext.harvest.logic import HarvestJobExists, NoNewHarvestJobError
 from ckanext.harvest.logic.schema import harvest_source_show_package_schema
 
 from ckanext.harvest.logic.action.get import harvest_source_show, harvest_job_list, _get_sources_for_user
@@ -365,7 +365,7 @@ def harvest_jobs_run(context,data_dict):
     jobs = harvest_job_list(context,{'source_id':source_id,'status':u'New'})
     if len(jobs) == 0:
         log.info('No new harvest jobs.')
-        raise Exception('There are no new harvesting jobs')
+        raise NoNewHarvestJobError('There are no new harvesting jobs')
 
     # Send each job to the gather queue
     publisher = get_gather_publisher()


### PR DESCRIPTION
If there are no harvesting jobs to run, there was always an ugly
exception message when using the paster command. This replaces the ugly
output with a proper message and uses a custom exception to allow others
to deal with this error differently.