### PR TITLE
Fix #105 by adapting harvest_source_clear to removal of authz models

### DIFF
--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -141,7 +141,7 @@ def harvest_source_clear(context,data_dict):
         (select id from package where state = 'to_delete');
         '''
     # CKAN pre-2.5: authz models were removed in migration 078
-    if toolkit.check_ckan_version(max_version='2.4'):
+    if toolkit.check_ckan_version(max_version='2.4.99'):
         sql += '''
         delete from user_object_role where id not in 
         (select user_object_role_id from package_role) and context = 'Package';

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -140,14 +140,22 @@ def harvest_source_clear(context,data_dict):
         delete from resource_group where package_id  in 
         (select id from package where state = 'to_delete');
         '''
+    # CKAN pre-2.5: authz models were removed in migration 078
+    if toolkit.check_ckan_version(max_version='2.4'):
+        sql += '''
+        delete from user_object_role where id not in 
+        (select user_object_role_id from package_role) and context = 'Package';
+        delete from package_role where package_id in 
+        (select id from package where state = 'to_delete');
+        '''
+
+
     sql += '''
     delete from harvest_object_error where harvest_object_id in (select id from harvest_object where harvest_source_id = '{harvest_source_id}');
     delete from harvest_object_extra where harvest_object_id in (select id from harvest_object where harvest_source_id = '{harvest_source_id}');
     delete from harvest_object where harvest_source_id = '{harvest_source_id}';
     delete from harvest_gather_error where harvest_job_id in (select id from harvest_job where source_id = '{harvest_source_id}');
     delete from harvest_job where source_id = '{harvest_source_id}';
-    delete from package_role where package_id in (select id from package where state = 'to_delete' );
-    delete from user_object_role where id not in (select user_object_role_id from package_role) and context = 'Package';
     delete from package_tag_revision where package_id in (select id from package where state = 'to_delete');
     delete from member_revision where table_id in (select id from package where state = 'to_delete');
     delete from package_extra_revision where package_id in (select id from package where state = 'to_delete');


### PR DESCRIPTION
## TL;DR
Fix #105 by upgrading harvest_source_clear to not delete from authz models removed in migration 078 for CKAN versions > 2.4.

## Details
Migration [078](https://github.com/ckan/ckan/blob/63e3bc9186f02a4bf1cce24b4c5d937e696c04c3/ckan/migration/versions/078_remove_old_authz_model.py) removes the legacy authz models, including `package_role` and `user_object_role`.
These two models are deleted from in `harvest_source_clear`. This PR moves the SQL queries to delete from the two corresponding tables to a conditional block which only runs for CKAN pre-2.5.

## Assumptions
* Migration 078 applies to versions >= 2.5. Maintainers: is that correct?
* The models `package_role` and `user_obkect_role` exist in CKAN up to version 2.4.

## Effect
* Harvest > View a harvesting source > Admin > Clear will work again.
* Works in CKAN 2.5, but untested in CKAN < 2.5