### PR TITLE
New API function harvest_source_patch

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -33,7 +33,9 @@ sudo service jetty restart
 
 echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
+sudo -u postgres psql -c "CREATE USER datastore_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
+sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan_default;'
 
 echo "Initialising the database..."
 cd ckan

--- a/ckanext/harvest/logic/action/patch.py
+++ b/ckanext/harvest/logic/action/patch.py
@@ -1,0 +1,58 @@
+'''API functions for partial updates of existing data in CKAN'''
+
+import logging
+from ckan.logic import get_action
+from ckanext.harvest.plugin import DATASET_TYPE_NAME
+
+log = logging.getLogger(__name__)
+
+
+def harvest_source_patch(context, data_dict):
+    '''
+    Patch an existing harvest source
+
+    This method just proxies the request to package_patch,
+    which will update a harvest_source dataset type and the
+    HarvestSource object. All auth checks and validation will
+    be done there. We only make sure to set the dataset type.
+
+    Note that the harvest source type (ckan, waf, csw, etc)
+    is now set via the source_type field.
+
+    All fields that are not provided, will be stay as they were before.
+
+    :param id: the name or id of the harvest source to update
+    :type id: string
+    :param url: the URL for the harvest source
+    :type url: string
+    :param name: the name of the new harvest source, must be between 2 and 100
+        characters long and contain only lowercase alphanumeric characters
+    :type name: string
+    :param title: the title of the dataset (optional, default: same as
+        ``name``)
+    :type title: string
+    :param notes: a description of the harvest source (optional)
+    :type notes: string
+    :param source_type: the harvester type for this source. This must be one
+        of the registerd harvesters, eg 'ckan', 'csw', etc.
+    :type source_type: string
+    :param frequency: the frequency in wich this harvester should run. See
+        ``ckanext.harvest.model`` source for possible values. Default is
+        'MANUAL'
+    :type frequency: string
+    :param config: extra configuration options for the particular harvester
+        type. Should be a serialized as JSON. (optional)
+    :type config: string
+
+    :returns: the updated harvest source
+    :rtype: dictionary
+    '''
+    log.info('Patch harvest source: %r', data_dict)
+
+    data_dict['type'] = DATASET_TYPE_NAME
+
+    context['extras_as_string'] = True
+    source = get_action('package_patch')(context, data_dict)
+
+    return source
+

--- a/ckanext/harvest/logic/action/patch.py
+++ b/ckanext/harvest/logic/action/patch.py
@@ -52,7 +52,11 @@ def harvest_source_patch(context, data_dict):
     data_dict['type'] = DATASET_TYPE_NAME
 
     context['extras_as_string'] = True
-    source = get_action('package_patch')(context, data_dict)
+    try:
+        source = get_action('package_patch')(context, data_dict)
+    except KeyError:
+        log.warn('This CKAN instance does not support package_patch, using package_update instead')
+        source = get_action('package_update')(context, data_dict)
 
     return source
 

--- a/ckanext/harvest/logic/action/patch.py
+++ b/ckanext/harvest/logic/action/patch.py
@@ -1,7 +1,7 @@
 '''API functions for partial updates of existing data in CKAN'''
 
 import logging
-from ckan.logic import get_action
+from ckan.logic import ActionError, get_action
 from ckanext.harvest.plugin import DATASET_TYPE_NAME
 
 log = logging.getLogger(__name__)
@@ -55,8 +55,8 @@ def harvest_source_patch(context, data_dict):
     try:
         source = get_action('package_patch')(context, data_dict)
     except KeyError:
-        log.warn('This CKAN instance does not support package_patch, using package_update instead')
-        source = get_action('package_update')(context, data_dict)
+        log.warn('This CKAN instance does not support package_patch, consider upgrading to CKAN >= 2.3 if needed.')
+        raise ActionError('The harvest_source_patch action is not available on this version of CKAN')
 
     return source
 

--- a/ckanext/harvest/logic/action/patch.py
+++ b/ckanext/harvest/logic/action/patch.py
@@ -1,7 +1,7 @@
 '''API functions for partial updates of existing data in CKAN'''
 
 import logging
-from ckan.logic import ActionError, get_action
+from ckan.logic import get_action
 from ckanext.harvest.plugin import DATASET_TYPE_NAME
 
 log = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ def harvest_source_patch(context, data_dict):
         source = get_action('package_patch')(context, data_dict)
     except KeyError:
         log.warn('This CKAN instance does not support package_patch, consider upgrading to CKAN >= 2.3 if needed.')
-        raise ActionError('The harvest_source_patch action is not available on this version of CKAN')
+        raise Exception('The harvest_source_patch action is not available on this version of CKAN')
 
     return source
 

--- a/ckanext/harvest/logic/auth/patch.py
+++ b/ckanext/harvest/logic/auth/patch.py
@@ -1,0 +1,3 @@
+import ckanext.harvest.logic.auth.update as _update
+
+harvest_source_patch = _update.harvest_source_update

--- a/ckanext/harvest/plugin.py
+++ b/ckanext/harvest/plugin.py
@@ -287,7 +287,7 @@ def _add_extra(data_dict, key, value):
 
 def _get_logic_functions(module_root, logic_functions = {}):
 
-    for module_name in ['get', 'create', 'update','delete']:
+    for module_name in ['get', 'create', 'update', 'patch', 'delete']:
         module_path = '%s.%s' % (module_root, module_name,)
 
         module = __import__(module_path)

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -1,5 +1,6 @@
 import json
 import copy
+import uuid
 import factories
 import unittest
 from nose.tools import assert_equal, assert_raises, ok_
@@ -163,8 +164,6 @@ class HarvestSourceActionBase(FunctionalTestBaseWithoutClearBetweenTests):
         super(HarvestSourceActionBase, cls).setup_class()
         harvest_model.setup()
 
-        cls.sysadmin = ckan_factories.Sysadmin()
-
         if not p.plugin_loaded('test_action_harvester'):
             p.load('test_action_harvester')
 
@@ -191,8 +190,9 @@ class HarvestSourceActionBase(FunctionalTestBaseWithoutClearBetweenTests):
         if 'id' in test_data:
             source_dict['id'] = test_data['id']
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api(self.action,
-                                 apikey=self.sysadmin['apikey'], status=409,
+                                 apikey=sysadmin['apikey'], status=409,
                                  **source_dict)
 
         for key in ('name', 'title', 'url', 'source_type'):
@@ -202,8 +202,9 @@ class HarvestSourceActionBase(FunctionalTestBaseWithoutClearBetweenTests):
         source_dict = self._get_source_dict()
         source_dict['source_type'] = 'unknown'
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api(self.action,
-                                 apikey=self.sysadmin['apikey'], status=409,
+                                 apikey=sysadmin['apikey'], status=409,
                                  **source_dict)
 
         ok_('source_type' in result)
@@ -214,8 +215,9 @@ class HarvestSourceActionBase(FunctionalTestBaseWithoutClearBetweenTests):
         source_dict = self._get_source_dict()
         source_dict['frequency'] = wrong_frequency
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api(self.action,
-                                 apikey=self.sysadmin['apikey'], status=409,
+                                 apikey=sysadmin['apikey'], status=409,
                                  **source_dict)
 
         ok_('frequency' in result)
@@ -225,8 +227,9 @@ class HarvestSourceActionBase(FunctionalTestBaseWithoutClearBetweenTests):
         source_dict = self._get_source_dict()
         source_dict['config'] = 'not_json'
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api(self.action,
-                                 apikey=self.sysadmin['apikey'], status=409,
+                                 apikey=sysadmin['apikey'], status=409,
                                  **source_dict)
 
         ok_('config' in result)
@@ -235,7 +238,7 @@ class HarvestSourceActionBase(FunctionalTestBaseWithoutClearBetweenTests):
         source_dict['config'] = json.dumps({'custom_option': 'not_a_list'})
 
         result = call_action_api(self.action,
-                                 apikey=self.sysadmin['apikey'], status=409,
+                                 apikey=sysadmin['apikey'], status=409,
                                  **source_dict)
 
         ok_('config' in result)
@@ -251,8 +254,9 @@ class TestHarvestSourceActionCreate(HarvestSourceActionBase):
 
         source_dict = self._get_source_dict()
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api('harvest_source_create',
-                                 apikey=self.sysadmin['apikey'], **source_dict)
+                                 apikey=sysadmin['apikey'], **source_dict)
 
         for key in source_dict.keys():
             assert_equal(source_dict[key], result[key])
@@ -267,7 +271,7 @@ class TestHarvestSourceActionCreate(HarvestSourceActionBase):
         source_dict['name'] = 'test-source-action-new'
 
         result = call_action_api('harvest_source_create',
-                                 apikey=self.sysadmin['apikey'], status=409,
+                                 apikey=sysadmin['apikey'], status=409,
                                  **source_dict)
 
         ok_('url' in result)
@@ -275,17 +279,19 @@ class TestHarvestSourceActionCreate(HarvestSourceActionBase):
 
 class HarvestSourceFixtureMixin(object):
     def _get_source_dict(self):
+        id = uuid.uuid4()
         template = {
-            "url": "http://test.action.com",
-            "name": "test-source-action",
+            "url": "http://test.action.com/%s" % id,
+            "name": "test-source-action%s" % id,
             "title": "Test source action",
             "notes": "Test source action desc",
             "source_type": "test-for-action",
             "frequency": "MANUAL",
             "config": json.dumps({"custom_option": ["a", "b"]})
         }
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api('harvest_source_create', 
-                                 apikey=self.sysadmin['apikey'], **template)
+                                 apikey=sysadmin['apikey'], **template)
         template['id'] = result['id']
         return template
 
@@ -305,8 +311,9 @@ class TestHarvestSourceActionUpdate(HarvestSourceFixtureMixin, HarvestSourceActi
             "config": json.dumps({"custom_option": ["c", "d"]})
         })
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api('harvest_source_update',
-                                 apikey=self.sysadmin['apikey'], **source_dict)
+                                 apikey=sysadmin['apikey'], **source_dict)
 
         for key in source_dict.keys():
             assert_equal(source_dict[key], result[key], "Key: %s" % key)
@@ -341,8 +348,9 @@ class TestHarvestSourceActionPatch(HarvestSourceFixtureMixin, HarvestSourceActio
             "config": json.dumps({"custom_option": ["pat", "ched"]})
         }
 
+        sysadmin = ckan_factories.Sysadmin()
         result = call_action_api('harvest_source_patch',
-                                 apikey=self.sysadmin['apikey'], **patch_dict)
+                                 apikey=sysadmin['apikey'], **patch_dict)
 
         source_dict.update(patch_dict)
         for key in source_dict.keys():

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -72,7 +72,7 @@ def call_action_api(action, apikey=None, status=200, **kwargs):
         response = app.post('/api/action/{0}'.format(action), params=params,
                             extra_environ={'Authorization': str(apikey)},
                             status=status)
-    except ActionError, e:
+    except Exception, e:
         if str(e) == 'The harvest_source_patch action is not available on this version of CKAN':
             raise SkipTest()
         raise e

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -3,6 +3,7 @@ import copy
 import factories
 import unittest
 from nose.tools import assert_equal, assert_raises
+from nose.plugins.skip import SkipTest
 
 try:
     from ckan.tests import factories as ckan_factories
@@ -324,19 +325,17 @@ class TestHarvestSourceActionPatch(HarvestSourceActionBase):
         cls.default_source_dict['id'] = result['id']
 
     def test_invalid_missing_values(self):
-        # patch should *NOT* return an error about missing values
-
-        # source_dict = {}
-        # source_dict['id'] = self.default_source_dict['id']
-
-        # result = call_action_api(self.action,
-        #                          apikey=self.sysadmin['apikey'], **source_dict)
-
-        # for key in ('name', 'title', 'url', 'source_type'):
-        #     assert result[key] == self.default_source_dict[key]
+        # patch should *NOT* return an error about missing values, so skip this test
         pass
 
     def test_patch(self):
+        # check if current version of CKAN supports package_patch
+        try:
+            toolkit.get_action('package_patch')
+        except KeyError:
+            # package_patch is not supported
+            raise SkipTest()
+
         patch_dict = {
             "id": self.default_source_dict['id'],
             "name": "test-source-action-patched",

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -307,6 +307,58 @@ class TestHarvestSourceActionUpdate(HarvestSourceActionBase):
         assert source.type == source_dict['source_type']
 
 
+class TestHarvestSourceActionPatch(HarvestSourceActionBase):
+
+    @classmethod
+    def setup_class(cls):
+
+        cls.action = 'harvest_source_patch'
+
+        super(TestHarvestSourceActionPatch, cls).setup_class()
+
+        # Create a source to udpate
+        source_dict = cls.default_source_dict
+        result = call_action_api('harvest_source_create',
+                                 apikey=cls.sysadmin['apikey'], **source_dict)
+
+        cls.default_source_dict['id'] = result['id']
+
+    def test_invalid_missing_values(self):
+        # patch should *NOT* return an error about missing values
+
+        # source_dict = {}
+        # source_dict['id'] = self.default_source_dict['id']
+
+        # result = call_action_api(self.action,
+        #                          apikey=self.sysadmin['apikey'], **source_dict)
+
+        # for key in ('name', 'title', 'url', 'source_type'):
+        #     assert result[key] == self.default_source_dict[key]
+        pass
+
+    def test_patch(self):
+        patch_dict = {
+            "id": self.default_source_dict['id'],
+            "name": "test-source-action-patched",
+            "url": "http://test.action.patched.com",
+            "config": json.dumps({"custom_option": ["pat", "ched"]})
+        }
+
+        result = call_action_api('harvest_source_patch',
+                                 apikey=self.sysadmin['apikey'], **patch_dict)
+
+        source_dict = self.default_source_dict
+        source_dict.update(patch_dict)
+
+        for key in source_dict.keys():
+            assert source_dict[key] == result[key]
+
+        # Check that source was actually updated
+        source = harvest_model.HarvestSource.get(result['id'])
+        assert source.url == source_dict['url']
+        assert source.type == source_dict['source_type']
+
+
 class TestActions(ActionBase):
     def test_harvest_source_clear(self):
         source = factories.HarvestSourceObj(**SOURCE_DICT)


### PR DESCRIPTION
Add a `harvest_source_patch` API function to be able to update a harvest source with only the changes you want to make. Internally this is a proxy to the already existing `package_patch`. This means it is only available in CKAN >= 2.3, in older versions `harvest_source_update` is used instead.