### PR TITLE
Raise general exceptions

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -1,4 +1,5 @@
 import urllib2
+import httplib
 
 from ckan.lib.base import c
 from ckan import model
@@ -50,7 +51,7 @@ class CKANHarvester(HarvesterBase):
                 'Could not fetch url: %s, error: %s' % 
                 (url, str(e))
             )
-        except Exception, e:
+        except httplib.HTTPException, e:
             raise ContentFetchError(
                 'Could not fetch url: %s, error: %s' %
                 (url, str(e))

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -50,6 +50,12 @@ class CKANHarvester(HarvesterBase):
                 'Could not fetch url: %s, error: %s' % 
                 (url, str(e))
             )
+        except Exception, e:
+            raise ContentFetchError(
+                'Could not fetch url: %s, error: %s' %
+                (url, str(e))
+            )
+
         return http_response.read()
 
     def _get_group(self, base_url, group_name):


### PR DESCRIPTION
Also raise ContentFetchError for general exceptions or sub its exceptions (i.e.`httplib.BadStatusLine`).