### PR TITLE
Use the ckan version of munge_tag if available, but provide a fallback

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -21,14 +21,14 @@ from ckanext.harvest.model import HarvestJob, HarvestObject, HarvestGatherError,
 from ckan.plugins.core import SingletonPlugin, implements
 from ckanext.harvest.interfaces import IHarvester
 
-try:
+if p.toolkit.check_ckan_version(min_verion='2.3'):
     from ckan.lib.munge import munge_tag
-except ImportError:
-    # Fallback for older ckan versions which don't have it
+else:
+    # Fallback for older ckan versions which don't have a decent munger
     def munge_tag(tag):
         tag = substitute_ascii_equivalents(tag)
         tag = tag.lower().strip()
-        return re.sub(r'[^a-zA-Z0-9 -]', '', tag).replace(' ', '-')
+        return re.sub(r'[^a-zA-Z0-9\- ]', '', tag).replace(' ', '-')
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -21,14 +21,16 @@ from ckanext.harvest.model import HarvestJob, HarvestObject, HarvestGatherError,
 from ckan.plugins.core import SingletonPlugin, implements
 from ckanext.harvest.interfaces import IHarvester
 
+try:
+    from ckan.lib.munge import munge_tag
+except ImportError:
+    # Fallback for older ckan versions which don't have it
+    def munge_tag(tag):
+        tag = substitute_ascii_equivalents(tag)
+        tag = tag.lower().strip()
+        return re.sub(r'[^a-zA-Z0-9 -]', '', tag).replace(' ', '-')
 
 log = logging.getLogger(__name__)
-
-
-def munge_tag(tag):
-    tag = substitute_ascii_equivalents(tag)
-    tag = tag.lower().strip()
-    return re.sub(r'[^a-zA-Z0-9 -]', '', tag).replace(' ', '-')
 
 
 class HarvesterBase(SingletonPlugin):

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -24,11 +24,22 @@ from ckanext.harvest.interfaces import IHarvester
 if p.toolkit.check_ckan_version(min_version='2.3'):
     from ckan.lib.munge import munge_tag
 else:
-    # Fallback for older ckan versions which don't have a decent munger
+    # Fallback munge_tag for older ckan versions which don't have a decent
+    # munger
+    def _munge_to_length(string, min_length, max_length):
+        '''Pad/truncates a string'''
+        if len(string) < min_length:
+            string += '_' * (min_length - len(string))
+        if len(string) > max_length:
+            string = string[:max_length]
+        return string
+
     def munge_tag(tag):
         tag = substitute_ascii_equivalents(tag)
         tag = tag.lower().strip()
-        return re.sub(r'[^a-zA-Z0-9\- ]', '', tag).replace(' ', '-')
+        tag = re.sub(r'[^a-zA-Z0-9\- ]', '', tag).replace(' ', '-')
+        tag = _munge_to_length(tag, model.MIN_TAG_LENGTH, model.MAX_TAG_LENGTH)
+        return tag
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -21,7 +21,7 @@ from ckanext.harvest.model import HarvestJob, HarvestObject, HarvestGatherError,
 from ckan.plugins.core import SingletonPlugin, implements
 from ckanext.harvest.interfaces import IHarvester
 
-if p.toolkit.check_ckan_version(min_verion='2.3'):
+if p.toolkit.check_ckan_version(min_version='2.3'):
     from ckan.lib.munge import munge_tag
 else:
     # Fallback for older ckan versions which don't have a decent munger

--- a/ckanext/harvest/tests/harvesters/test_base.py
+++ b/ckanext/harvest/tests/harvesters/test_base.py
@@ -2,7 +2,7 @@ import re
 
 from nose.tools import assert_equal
 from ckanext.harvest import model as harvest_model
-from ckanext.harvest.harvesters.base import HarvesterBase
+from ckanext.harvest.harvesters.base import HarvesterBase, munge_tag
 try:
     from ckan.tests import helpers
     from ckan.tests import factories
@@ -96,3 +96,30 @@ class TestEnsureNameIsUnique(object):
         name = _ensure_name_is_unique('trees', append_type='random-hex')
         # e.g. 'trees0b53f'
         assert re.match('trees[\da-f]{5}', name)
+
+
+# taken from ckan/tests/lib/test_munge.py
+class TestMungeTag:
+
+    # (original, expected)
+    munge_list = [
+        ('unchanged', 'unchanged'),
+        ('s', 's_'),  # too short
+        ('some spaces  here', 'some-spaces--here'),
+        ('random:other%characters&_.here', 'randomothercharactershere'),
+        ('river-water-dashes', 'river-water-dashes'),
+    ]
+
+    def test_munge_tag(self):
+        '''Munge a list of tags gives expected results.'''
+        for org, exp in self.munge_list:
+            munge = munge_tag(org)
+            assert_equal(munge, exp)
+
+    def test_munge_tag_multiple_pass(self):
+        '''Munge a list of tags muliple times gives expected results.'''
+        for org, exp in self.munge_list:
+            first_munge = munge_tag(org)
+            assert_equal(first_munge, exp)
+            second_munge = munge_tag(first_munge)
+            assert_equal(second_munge, exp)


### PR DESCRIPTION
(fallback is for older ckans)