### PR TITLE
Fix MockCkan - revision APIv2 returned names not IDs

### DIFF
--- a/ckanext/harvest/tests/harvesters/mock_ckan.py
+++ b/ckanext/harvest/tests/harvesters/mock_ckan.py
@@ -64,6 +64,7 @@ class MockCkanHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             return self.respond_json(revision_ids)
         if self.path.startswith('/api/rest/revision/'):
             revision_ref = self.path.split('/')[-1]
+            assert api_version == 2
             for rev in REVISIONS:
                 if rev['id'] == revision_ref:
                     return self.respond_json(rev)
@@ -440,7 +441,7 @@ REVISIONS = [
     "approved_timestamp": None,
     "packages":
     [
-        DATASETS[1]['name']
+        DATASETS[1]['id']
     ],
     "groups": [ ]
     },
@@ -452,7 +453,7 @@ REVISIONS = [
     "approved_timestamp": None,
     "packages":
     [
-        DATASETS[1]['name']
+        DATASETS[1]['id']
     ],
     "groups": [ ]
     }]

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -106,7 +106,7 @@ class TestCkanHarvester(object):
                 harvester=CKANHarvester())
 
         # updated the dataset which has revisions
-        result = results_by_guid[mock_ckan.DATASETS[1]['name']]
+        result = results_by_guid[mock_ckan.DATASETS[1]['id']]
         assert_equal(result['state'], 'COMPLETE')
         assert_equal(result['report_status'], 'updated')
         assert_equal(result['dataset']['name'], mock_ckan.DATASETS[1]['name'])
@@ -155,7 +155,7 @@ class TestCkanHarvester(object):
 
         # The metadata_modified was the same for this dataset so the import
         # would have returned 'unchanged'
-        result = results_by_guid[mock_ckan.DATASETS[1]['name']]
+        result = results_by_guid[mock_ckan.DATASETS[1]['id']]
         assert_equal(result['state'], 'COMPLETE')
         assert_equal(result['report_status'], 'not modified')
         assert 'dataset' not in result


### PR DESCRIPTION
CKAN revision API returns package ids not names (for v2 of the API), so fix this with the MockCkan. The tests now show the the harvest guid is always the package ID rather than the name.