### PR TITLE
Fix name of class to enable automatic conversion of datetimes

### DIFF
--- a/ckanext/harvest/templates_new/snippets/job_details.html
+++ b/ckanext/harvest/templates_new/snippets/job_details.html
@@ -51,7 +51,7 @@ Example:
   <tr>
     <th>{{ _('Created') }}</th>
     <td>
-        <span class="datetime" data-datetime="{{ h.render_datetime(job.created, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+        <span class="automatic-local-datetime" data-datetime="{{ h.render_datetime(job.created, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
             {{ h.render_datetime(job.created, with_hours=True) }}
         </span>
     </td>
@@ -59,7 +59,7 @@ Example:
   <tr>
     <th>{{ _('Started') }}</th>
     <td>
-        <span class="datetime" data-datetime="{{ h.render_datetime(job.gather_started, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+        <span class="automatic-local-datetime" data-datetime="{{ h.render_datetime(job.gather_started, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
             {{ h.render_datetime(job.gather_started, with_hours=True) }}
         </span>
     </td>
@@ -67,7 +67,7 @@ Example:
   <tr>
     <th>{{ _('Finished') }}</th>
     <td>
-        <span class="datetime" data-datetime="{{ h.render_datetime(job.finished, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+        <span class="automatic-local-datetime" data-datetime="{{ h.render_datetime(job.finished, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
             {{ h.render_datetime(job.finished, with_hours=True) }}
         </span>
     </td>

--- a/ckanext/harvest/templates_new/source/job/list.html
+++ b/ckanext/harvest/templates_new/source/job/list.html
@@ -26,12 +26,12 @@
             </h3>
             <p>
               {{ _('Started:') }}
-              <span class="datetime" data-datetime="{{ h.render_datetime(job.gather_started, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+              <span class="automatic-local-datetime" data-datetime="{{ h.render_datetime(job.gather_started, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
                 {{ h.render_datetime(job.gather_started, with_hours=True) or _('Not yet') }}
               </span>
               &mdash;
               {{ _('Finished:') }}
-              <span class="datetime" data-datetime="{{ h.render_datetime(job.finished, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
+              <span class="automatic-local-datetime" data-datetime="{{ h.render_datetime(job.finished, date_format='%Y-%m-%dT%H:%M:%S%z') }}">
                 {{ h.render_datetime(job.finished, with_hours=True) or _('Not yet') }}
               </span>
             </p>


### PR DESCRIPTION
When ckan/ckan#2505 got finally merged, the class name to mark datetimes
with a time part that can be automatically converted to the users
timezone, changed.
This PR makes sure this change is reflected in ckanext-harvest.

This is a fix for the change introduced in #142 