### PR TITLE
Fetch stage can also return "unchanged", same as the import stage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,11 +339,10 @@ following methods::
     '''
     implements(IHarvester)
 
-
     def info(self):
         '''
-        Harvesting implementations must provide this method, which will return a
-        dictionary containing different descriptors of the harvester. The
+        Harvesting implementations must provide this method, which will return
+        a dictionary containing different descriptors of the harvester. The
         returned dictionary should contain:
 
         * name: machine-readable name. This will be the value stored in the
@@ -351,8 +350,8 @@ following methods::
           harvester.
         * title: human-readable name. This will appear in the form's select box
           in the WUI.
-        * description: a small description of what the harvester does. This will
-          appear on the form as a guidance to the user.
+        * description: a small description of what the harvester does. This
+          will appear on the form as a guidance to the user.
 
         A complete example may be::
 
@@ -371,9 +370,10 @@ following methods::
 
         [optional]
 
-        Harvesters can provide this method to validate the configuration entered in the
-        form. It should return a single string, which will be stored in the database.
-        Exceptions raised will be shown in the form's error messages.
+        Harvesters can provide this method to validate the configuration
+        entered in the form. It should return a single string, which will be
+        stored in the database.  Exceptions raised will be shown in the form's
+        error messages.
 
         :param harvest_object_id: Config string coming from the form
         :returns: A string with the validated configuration options
@@ -404,7 +404,7 @@ following methods::
 
     def gather_stage(self, harvest_job):
         '''
-        The gather stage will recieve a HarvestJob object and will be
+        The gather stage will receive a HarvestJob object and will be
         responsible for:
             - gathering all the necessary objects to fetch on a later.
               stage (e.g. for a CSW server, perform a GetRecords request)
@@ -430,10 +430,14 @@ following methods::
             - saving the content in the provided HarvestObject.
             - creating and storing any suitable HarvestObjectErrors that may
               occur.
-            - returning True if everything went as expected, False otherwise.
+            - returning True if everything is ok (ie the object should now be
+              imported), "unchanged" if the object didn't need harvesting after
+              all (ie no error, but don't continue to import stage) or False if
+              there were errors.
 
         :param harvest_object: HarvestObject object
-        :returns: True if everything went right, False if errors were found
+        :returns: True if successful, 'unchanged' if nothing to import after
+                  all, False if not successful
         '''
 
     def import_stage(self, harvest_object):
@@ -452,12 +456,13 @@ following methods::
               objects of this harvest source if the action was successful.
             - creating and storing any suitable HarvestObjectErrors that may
               occur.
-            - returning True if the action was done, "unchanged" if nothing
-              was needed doing after all or False if there were errors.
+            - creating the HarvestObject - Package relation (if necessary)
+            - returning True if the action was done, "unchanged" if the object
+              didn't need harvesting after all or False if there were errors.
 
         :param harvest_object: HarvestObject object
-        :returns: True if the action was done, "unchanged" if nothing was
-                  needed doing after all and False if something went wrong.
+        :returns: True if the action was done, "unchanged" if the object didn't
+                  need harvesting after all or False if there were errors.
         '''
 
 

--- a/README.rst
+++ b/README.rst
@@ -416,6 +416,8 @@ following methods::
             - creating and storing any suitable HarvestGatherErrors that may
               occur.
             - returning a list with all the ids of the created HarvestObjects.
+            - to abort the harvest, create a HarvestGatherError and raise an
+              exception. Any created HarvestObjects will be deleted.
 
         :param harvest_job: HarvestJob object
         :returns: A list of HarvestObject ids

--- a/README.rst
+++ b/README.rst
@@ -462,6 +462,8 @@ following methods::
             - returning True if the action was done, "unchanged" if the object
               didn't need harvesting after all or False if there were errors.
 
+        NB You can run this stage repeatedly using 'paster harvest import'.
+
         :param harvest_object: HarvestObject object
         :returns: True if the action was done, "unchanged" if the object didn't
                   need harvesting after all or False if there were errors.

--- a/ckanext/harvest/interfaces.py
+++ b/ckanext/harvest/interfaces.py
@@ -130,6 +130,8 @@ class IHarvester(Interface):
             - returning True if the action was done, "unchanged" if the object
               didn't need harvesting after all or False if there were errors.
 
+        NB You can run this stage repeatedly using 'paster harvest import'.
+
         :param harvest_object: HarvestObject object
         :returns: True if the action was done, "unchanged" if the object didn't
                   need harvesting after all or False if there were errors.

--- a/ckanext/harvest/interfaces.py
+++ b/ckanext/harvest/interfaces.py
@@ -8,8 +8,8 @@ class IHarvester(Interface):
 
     def info(self):
         '''
-        Harvesting implementations must provide this method, which will return a
-        dictionary containing different descriptors of the harvester. The
+        Harvesting implementations must provide this method, which will return
+        a dictionary containing different descriptors of the harvester. The
         returned dictionary should contain:
 
         * name: machine-readable name. This will be the value stored in the
@@ -17,8 +17,8 @@ class IHarvester(Interface):
           harvester.
         * title: human-readable name. This will appear in the form's select box
           in the WUI.
-        * description: a small description of what the harvester does. This will
-          appear on the form as a guidance to the user.
+        * description: a small description of what the harvester does. This
+          will appear on the form as a guidance to the user.
 
         A complete example may be::
 
@@ -37,9 +37,10 @@ class IHarvester(Interface):
 
         [optional]
 
-        Harvesters can provide this method to validate the configuration entered in the
-        form. It should return a single string, which will be stored in the database.
-        Exceptions raised will be shown in the form's error messages.
+        Harvesters can provide this method to validate the configuration
+        entered in the form. It should return a single string, which will be
+        stored in the database.  Exceptions raised will be shown in the form's
+        error messages.
 
         :param harvest_object_id: Config string coming from the form
         :returns: A string with the validated configuration options
@@ -96,7 +97,10 @@ class IHarvester(Interface):
             - saving the content in the provided HarvestObject.
             - creating and storing any suitable HarvestObjectErrors that may
               occur.
-            - returning True if everything went as expected, False otherwise.
+            - returning True if everything is ok (ie the object should now be
+              imported), "unchanged" if the object didn't need harvesting after
+              all (ie no error, but don't continue to import stage) or False if
+              there were errors.
 
         :param harvest_object: HarvestObject object
         :returns: True if everything went right, False if errors were found
@@ -118,8 +122,8 @@ class IHarvester(Interface):
               objects of this harvest source if the action was successful.
             - creating and storing any suitable HarvestObjectErrors that may
               occur.
-            - returning True if the action was done, "unchanged" if nothing
-              was needed doing after all or False if there were errors.
+            - returning True if the action was done, "unchanged" if the object
+              didn't need harvesting after all or False if there were errors.
 
         :param harvest_object: HarvestObject object
         :returns: True if the action was done, "unchanged" if nothing was

--- a/ckanext/harvest/interfaces.py
+++ b/ckanext/harvest/interfaces.py
@@ -84,6 +84,8 @@ class IHarvester(Interface):
             - creating and storing any suitable HarvestGatherErrors that may
               occur.
             - returning a list with all the ids of the created HarvestObjects.
+            - to abort the harvest, create a HarvestGatherError and raise an
+              exception. Any created HarvestObjects will be deleted.
 
         :param harvest_job: HarvestJob object
         :returns: A list of HarvestObject ids

--- a/ckanext/harvest/interfaces.py
+++ b/ckanext/harvest/interfaces.py
@@ -1,5 +1,6 @@
 from ckan.plugins.interfaces import Interface
 
+
 class IHarvester(Interface):
     '''
     Common harvesting interface
@@ -71,7 +72,7 @@ class IHarvester(Interface):
 
     def gather_stage(self, harvest_job):
         '''
-        The gather stage will recieve a HarvestJob object and will be
+        The gather stage will receive a HarvestJob object and will be
         responsible for:
             - gathering all the necessary objects to fetch on a later.
               stage (e.g. for a CSW server, perform a GetRecords request)
@@ -103,7 +104,8 @@ class IHarvester(Interface):
               there were errors.
 
         :param harvest_object: HarvestObject object
-        :returns: True if everything went right, False if errors were found
+        :returns: True if successful, 'unchanged' if nothing to import after
+                  all, False if not successful
         '''
 
     def import_stage(self, harvest_object):
@@ -122,10 +124,11 @@ class IHarvester(Interface):
               objects of this harvest source if the action was successful.
             - creating and storing any suitable HarvestObjectErrors that may
               occur.
+            - creating the HarvestObject - Package relation (if necessary)
             - returning True if the action was done, "unchanged" if the object
               didn't need harvesting after all or False if there were errors.
 
         :param harvest_object: HarvestObject object
-        :returns: True if the action was done, "unchanged" if nothing was
-                  needed doing after all and False if something went wrong.
+        :returns: True if the action was done, "unchanged" if the object didn't
+                  need harvesting after all or False if there were errors.
         '''

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -395,7 +395,7 @@ def fetch_and_import_stages(harvester, obj):
     success_fetch = harvester.fetch_stage(obj)
     obj.fetch_finished = datetime.datetime.utcnow()
     obj.save()
-    if success_fetch:
+    if success_fetch is True:
         # If no errors where found, call the import method
         obj.import_started = datetime.datetime.utcnow()
         obj.state = "IMPORT"
@@ -411,6 +411,11 @@ def fetch_and_import_stages(harvester, obj):
         else:
             obj.state = "ERROR"
         obj.save()
+    elif success_fetch == 'unchanged':
+        obj.state = 'COMPLETE'
+        obj.report_status = 'not modified'
+        obj.save()
+        return
     else:
         obj.state = "ERROR"
         obj.save()


### PR DESCRIPTION
Used by DGU ckan harvester: https://github.com/datagovuk/ckanext-harvest/blob/b17ec8a28ebe87febba7e016e2077d060fb340d1/ckanext/harvest/harvesters/ckanharvester.py#L296-L311

It is useful to skip a harvest object like this, to avoid saving the fetched content in a HarvestObject (saves disk usage).