### PR TITLE
Remove inconsistent stats

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -128,7 +128,6 @@ def harvest_source_list(context, data_dict):
 
     sources = _get_sources_for_user(context, data_dict)
 
-    context.update({'detailed':False})
     return [harvest_source_dictize(source, context) for source in sources]
 
 

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -131,30 +131,6 @@ def harvest_source_list(context, data_dict):
     context.update({'detailed':False})
     return [harvest_source_dictize(source, context) for source in sources]
 
-@side_effect_free
-def harvest_source_for_a_dataset(context, data_dict):
-    '''
-    TODO: Deprecated, harvest source id is added as an extra to each dataset
-    automatically
-    '''
-    '''For a given dataset, return the harvest source that
-    created or last updated it, otherwise NotFound.'''
-
-    model = context['model']
-    session = context['session']
-
-    dataset_id = data_dict.get('id')
-
-    query = session.query(HarvestSource)\
-            .join(HarvestObject)\
-            .filter_by(package_id=dataset_id)\
-            .order_by(HarvestObject.gathered.desc())
-    source = query.first() # newest
-
-    if not source:
-        raise NotFound
-
-    return harvest_source_dictize(source,context)
 
 @side_effect_free
 def harvest_job_show(context,data_dict):

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -473,7 +473,6 @@ def harvest_send_job_to_gather_queue(context, data_dict):
         context, {'id': job_id})
 
     # Check the source is active
-    context['detailed'] = False
     source = harvest_source_show(context, {'id': job['source_id']})
     if not source['active']:
         raise toolkit.ValidationError('Source is not active')

--- a/ckanext/harvest/tests/test_queue.py
+++ b/ckanext/harvest/tests/test_queue.py
@@ -254,7 +254,6 @@ class TestHarvestQueue(object):
         )
         assert_equal(harvest_job['stats'], {'added': 0, 'updated': 2, 'not modified': 0, 'errored': 0, 'deleted': 1})
 
-        context['detailed'] = True
         harvest_source_dict = logic.get_action('harvest_source_show')(
             context,
             {'id': harvest_source['id']}


### PR DESCRIPTION
Fixes #205. See issue for full working.

Basically we remove two deprecated things because their job stats keys are inconsistent with `harvest_job_show`, `harvest_job_list` and `harvest_source_show_status['last_job']`.

* Remove harvest_source_for_a_dataset action - has been deprecated since Mar 6 16:54:33 2013 and returns wrong harvest stats keys.
* "detailed" source status is removed. Now we have lost harvest_source_for_a_dataset it is not possible to call it. And it returned the wrong keys anyway.