### PR TITLE
Add option to re-import based on guid.

### DIFF
--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -67,7 +67,7 @@ class Harvester(CkanCommand):
           WARNING: if using Redis, this command purges all data in the current
           Redis database
 
-      harvester [-j] [-o] [--segments={segments}] import [{source-id}]
+      harvester [-j] [-o|-g|-p {id/guid}] [--segments={segments}] import [{source-id}]
         - perform the import stage with the last fetched objects, for a certain
           source or a single harvest object. Please note that no objects will
           be fetched from the remote server. It will only affect the objects
@@ -75,6 +75,7 @@ class Harvester(CkanCommand):
 
           To import a particular harvest source, specify its id as an argument.
           To import a particular harvest object use the -o option.
+          To import a particular guid use the -g option.
           To import a particular package use the -p option.
 
           You will need to specify the -j flag in cases where the datasets are
@@ -111,10 +112,13 @@ class Harvester(CkanCommand):
             action='store_true', default=False, help='Do not join harvest objects to existing datasets')
 
         self.parser.add_option('-o', '--harvest-object-id', dest='harvest_object_id',
-            default=False, help='Id of the harvest object to which perfom the import stage')
+            default=False, help='Id of the harvest object to which perform the import stage')
 
         self.parser.add_option('-p', '--package-id', dest='package_id',
-            default=False, help='Id of the package whose harvest object to perfom the import stage for')
+            default=False, help='Id of the package whose harvest object to perform the import stage for')
+
+        self.parser.add_option('-g', '--guid', dest='guid',
+            default=False, help='Guid of the harvest object to which perform the import stage for')
 
         self.parser.add_option('--segments', dest='segments',
             default=False, help=
@@ -445,6 +449,7 @@ class Harvester(CkanCommand):
                 'source_id': source_id,
                 'harvest_object_id': self.options.harvest_object_id,
                 'package_id': self.options.package_id,
+                'guid': self.options.guid,
                 })
 
         print '%s objects reimported' % objs_count

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -262,6 +262,8 @@ def harvest_objects_import(context, data_dict):
 
     :param source_id: the id of the harvest source to import
     :type source_id: string
+    :param guid: the guid of the harvest object to import
+    :type guid: string
     :param harvest_object_id: the id of the harvest object to import
     :type harvest_object_id: string
     :param package_id: the id or name of the package to import
@@ -273,6 +275,7 @@ def harvest_objects_import(context, data_dict):
     model = context['model']
     session = context['session']
     source_id = data_dict.get('source_id')
+    guid = data_dict.get('guid')
     harvest_object_id = data_dict.get('harvest_object_id')
     package_id_or_name = data_dict.get('package_id')
 
@@ -280,7 +283,13 @@ def harvest_objects_import(context, data_dict):
 
     join_datasets = context.get('join_datasets', True)
 
-    if source_id:
+    if guid:
+        last_objects_ids = \
+            session.query(HarvestObject.id) \
+                   .filter(HarvestObject.guid == guid) \
+                   .filter(HarvestObject.current == True)
+
+    elif source_id:
         source = HarvestSource.get(source_id)
         if not source:
             log.error('Harvest source %s does not exist', source_id)


### PR DESCRIPTION
I use this quite a lot, so thought it worth adding into master.
e.g.
```
$ paster --plugin=ckanext-harvest harvester import -g 2acea1da-d54c-44bc-b1c3-3eeafd8ad23a -c $CKAN_INI
2015-12-08 16:17:00,248 DEBUG [ckanext.harvest.model] Harvest tables defined in memory
2015-12-08 16:17:00,248 DEBUG [ckanext.harvest.model] Harvest tables already exist

2015-12-08 16:17:00,431 DEBUG [ckanext.harvest.model] Harvest tables already exist
DB tables created
2015-12-08 16:17:00,447 INFO  [ckanext.harvest.logic.action.update] Harvest objects import: {'source_id': None, 'package_id': False, 'guid': '2acea1da-d54c-44bc-b1c3-3eeafd8ad23a', 'harvest_object_id': False}
2015-12-08 16:17:00,527 DEBUG [ckanext.harvest.harvesters.ckanharvester] In CKANHarvester import_stage
2015-12-08 16:17:00,647 INFO  [ckanext.harvest.harvesters.base] Package with GUID 2acea1da-d54c-44bc-b1c3-3eeafd8ad23a not updated, skipping...
2015-12-08 16:17:00,647 INFO  [ckanext.harvest.logic.action.update] Harvest objects imported: 1
1 objects reimported
```