### PR TITLE
Fix tests for ckan 2.2

### DIFF
--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -15,8 +15,13 @@ except ImportError:
     try:
         from ckan.new_tests.helpers import assert_in
     except ImportError:
-        # ckan 2.2 only has it in the legacy test helpers
-        from ckan.tests.helpers import assert_in
+        # for ckan 2.2
+        try:
+            from nose.tools import assert_in
+        except ImportError:
+            # Python 2.6 doesn't have it
+            def assert_in(a, b, msg=None):
+                assert a in b, msg or '%r was not in %r' % (a, b)
 
 from ckan import plugins as p
 from ckan.plugins import toolkit

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -11,7 +11,13 @@ try:
 except ImportError:
     from ckan.new_tests import factories as ckan_factories
     from ckan.new_tests.helpers import (_get_test_app, reset_db,
-                                        FunctionalTestBase, assert_in)
+                                        FunctionalTestBase)
+    try:
+        from ckan.new_tests.helpers import assert_in
+    except ImportError:
+        # ckan 2.2 only has it in the legacy test helpers
+        from ckan.tests.helpers import assert_in
+
 from ckan import plugins as p
 from ckan.plugins import toolkit
 from ckan import model


### PR DESCRIPTION
Following on from https://github.com/ckan/ckanext-harvest/pull/213#discussion_r47223762

I did this fix on another branch before I saw that. That's also a way to do it, but it does break DRY as assert_in is available in the legacy tests in ckan 2.2, so neither solution is perfect. I can't see a lot of point trying to make the harvest tests compatible with ckan pre 2.2... But if you feel its better, I'll change to that way.