### PR TITLE
Swap import statements to make sure `run_test` works on CKAN 2.3

### DIFF
--- a/ckanext/harvest/tests/factories.py
+++ b/ckanext/harvest/tests/factories.py
@@ -1,9 +1,9 @@
 import factory
 import ckanext.harvest.model as harvest_model
 try:
-    from ckan.tests.factories import _get_action_user_name
-except ImportError:
     from ckan.new_tests.factories import _get_action_user_name
+except ImportError:
+    from ckan.tests.factories import _get_action_user_name
 from ckan.plugins import toolkit
 
 

--- a/ckanext/harvest/tests/test_auth.py
+++ b/ckanext/harvest/tests/test_auth.py
@@ -7,9 +7,11 @@ from ckan.model import Package, Session
 from ckan.lib.helpers import url_for,json
 from ckan.lib.base import config
 
-
-from ckan.tests import CreateTestData
 #TODO: remove references to old tests
+try:
+    from ckan.tests import CreateTestData
+except ImportError:
+    from ckan.tests.legacy import CreateTestData
 try:
     from ckan.tests.functional.base import FunctionalTestCase
 except ImportError:


### PR DESCRIPTION
Fixes #217, thanks @davidread for the hint.

I tested this on both CKAN 2.3 and CKAN 2.4, and it works like a charm!