### PR TITLE
Exclude custom 'harvester' datatype from the search results

### DIFF
--- a/ckanext/harvest/plugin.py
+++ b/ckanext/harvest/plugin.py
@@ -87,6 +87,17 @@ class Harvest(p.SingletonPlugin, DefaultDatasetForm, DefaultTranslation):
         return data_dict
 
 
+    def before_search(self, search_params):
+        '''Prevents the harvesters being shown in dataset search results.'''
+
+        fq = search_params.get('fq', '')
+        if 'dataset_type:{0}'.format('harvest') not in fq:
+            fq = "{0} -dataset_type:{1}".format(search_params.get('fq', ''),
+                                                'harvest')
+            search_params.update({'fq': fq})
+
+        return search_params
+
     def after_show(self, context, data_dict):
 
         if 'type' in data_dict and data_dict['type'] == DATASET_TYPE_NAME:


### PR DESCRIPTION
Prevent the 'harvest' datasets being shown in the group and dataset search results.

This is the change discussed in this ticket: https://github.com/ckan/ckanext-harvest/issues/220

I applied the fix which @metaodi and @wardi suggested in the ticket: https://github.com/ckan/ckanext-showcase/blob/da5e28b91c011aa8f5417082a6320d4d23021e78/ckanext/showcase/plugin.py#L244-L255
