### PR TITLE
Replace deprecated nav_named_link by nav_link

### DIFF
--- a/ckanext/harvest/templates/source/admin_base.html
+++ b/ckanext/harvest/templates/source/admin_base.html
@@ -29,7 +29,7 @@
       </a>
     {{ '</li>' if show_li }}
 
-  {{ '<li>' if show_li }}{{ h.nav_named_link(_('View harvest source'), '{0}_read'.format(c.dataset_type), id=source.name, class_='btn', icon='eye-open')}}{{ '</li>' if show_li }}
+  {{ '<li>' if show_li }}{{ h.nav_link(_('View harvest source'), named_route='{0}_read'.format(c.dataset_type), id=source.name, class_='btn', icon='eye-open')}}{{ '</li>' if show_li }}
 {% endblock %}
 
 {# CKAN 2.0 #}

--- a/ckanext/harvest/templates/source/base.html
+++ b/ckanext/harvest/templates/source/base.html
@@ -14,12 +14,12 @@
 {% block breadcrumb_content %}
   {% if source.organization %}
     {% set org = source.organization %}
-    <li>{{ h.nav_named_link(_('Organizations'), 'organizations_index') }}</li>
-    <li>{{ h.nav_named_link(org.title or org.name|truncate(10), 'organization_read', id=org.name) }}</li>
-    <li>{{ h.nav_named_link(_('Harvest Sources'), '{0}_search'.format(c.dataset_type)) }}</li>
-    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_named_link(c.harvest_source.title|truncate(10), '{0}_read'.format(c.dataset_type), id=c.harvest_source.name) }}</li>
+    <li>{{ h.nav_link(_('Organizations'), named_route='organizations_index') }}</li>
+    <li>{{ h.nav_link(org.title or org.name|truncate(10), named_route='organization_read', id=org.name) }}</li>
+    <li>{{ h.nav_link(_('Harvest Sources'), named_route='{0}_search'.format(c.dataset_type)) }}</li>
+    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(c.harvest_source.title|truncate(10), named_route='{0}_read'.format(c.dataset_type), id=c.harvest_source.name) }}</li>
   {% else %}
-    <li>{{ h.nav_named_link(_('Harvest Sources'), '{0}_search'.format(c.dataset_type)) }}</li>
-    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_named_link(c.harvest_source.title|truncate(30), '{0}_read'.format(c.dataset_type), id=c.harvest_source.name) }}</li>
+    <li>{{ h.nav_link(_('Harvest Sources'), named_route='{0}_search'.format(c.dataset_type)) }}</li>
+    <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(c.harvest_source.title|truncate(30), named_route='{0}_read'.format(c.dataset_type), id=c.harvest_source.name) }}</li>
   {% endif %}
 {% endblock %}

--- a/ckanext/harvest/templates/source/job/read.html
+++ b/ckanext/harvest/templates/source/job/read.html
@@ -6,7 +6,7 @@
 <div class="module-content">
 
   <p class="pull-right">
-    {{ h.nav_named_link(_('Back to job list'), 'harvest_job_list', source=source.name, class_='btn', icon='arrow-left')}}
+    {{ h.nav_link(_('Back to job list'), named_route='harvest_job_list', source=source.name, class_='btn', icon='arrow-left')}}
   </p>
 
   <h1>{{ _('Job Report') }}</h1>

--- a/ckanext/harvest/templates/source/read_base.html
+++ b/ckanext/harvest/templates/source/read_base.html
@@ -1,7 +1,7 @@
 {% extends "source/base.html" %}
 
 {% block admin_link %}
-  {{ h.nav_named_link(_('Admin'), '{0}_admin'.format(c.dataset_type), id=c.harvest_source.name, class_='btn btn-primary', icon='wrench')}}
+  {{ h.nav_link(_('Admin'), named_route='{0}_admin'.format(c.dataset_type), id=c.harvest_source.name, class_='btn btn-primary', icon='wrench')}}
 {% endblock %}
 
 {# CKAN 2.0 #}
@@ -19,7 +19,7 @@
       {% if c.harvest_source.notes %}
         <p>
           {{ h.markdown_extract(c.harvest_source.notes, 180) }}
-          {{ h.nav_named_link(_('read more'), '{0}_about'.format(c.dataset_type), id=c.harvest_source.name) }}
+          {{ h.nav_link(_('read more'), named_route='{0}_about'.format(c.dataset_type), id=c.harvest_source.name) }}
         </p>
       {% else %}
         <p class="empty">{{ _('There is no description for this harvest source') }}</p>

--- a/ckanext/harvest/templates/source/search.html
+++ b/ckanext/harvest/templates/source/search.html
@@ -4,7 +4,7 @@
 
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_named_link(_('Harvest Sources'), '{0}_search'.format(c.dataset_type)) }}</li>
+  <li class="active">{{ h.nav_link(_('Harvest Sources'), named_route='{0}_search'.format(c.dataset_type)) }}</li>
 {% endblock %}
 
 


### PR DESCRIPTION
Getting rid of warnings such as:
```
2016-03-02 10:41:16,658 WARNI [ckan.lib.maintain] Function nav_named_link() in module ckan.lib.helpers has been deprecated and will be removed in a later release of ckan. h.nav_named_link is deprecated please use h.nav_link
NOTE: you will need to pass the route_name as a named parameter
```

The deprecation is from CKAN 2.0 according to ckan/lib/helpers.py.