### PR TITLE
Unicode encode error with scandinavian facet filters

### DIFF
--- a/ckanext/harvest/plugin.py
+++ b/ckanext/harvest/plugin.py
@@ -92,7 +92,7 @@ class Harvest(p.SingletonPlugin, DefaultDatasetForm, DefaultTranslation):
 
         fq = search_params.get('fq', '')
         if 'dataset_type:harvest' not in fq:
-            fq = "{0} -dataset_type:harvest".format(search_params.get('fq', ''))
+            fq = u"{0} -dataset_type:harvest".format(search_params.get('fq', ''))
             search_params.update({'fq': fq})
 
         return search_params


### PR DESCRIPTION
If there are scandinavian alhabets (ä,ö and å) in tags or some other facets, harvest will throw UnicodeEncodeError while filtering with those facet.

This small PR will fix this error, since the search url is given to harvest plugin.