### PR TITLE
Fix deprecated nav_named_link

### DIFF
--- a/ckanext/harvest/templates/source/new.html
+++ b/ckanext/harvest/templates/source/new.html
@@ -1,8 +1,8 @@
 {% extends "source/admin_base.html" %}
 
 {% block breadcrumb_content %}
-  <li>{{ h.nav_named_link(_('Harvest Sources'), '{0}_search'.format(c.dataset_type)) }}</li>
-  <li class="active">{{ h.nav_named_link(_('Create Harvest Source'), '{0}_new'.format(c.dataset_type)) }}</li>
+  <li>{{ h.nav_link(_('Harvest Sources'), named_route='{0}_search'.format(c.dataset_type)) }}</li>
+  <li class="active">{{ h.nav_link(_('Create Harvest Source'), named_route='{0}_new'.format(c.dataset_type)) }}</li>
 {% endblock %}
 
 {% block actions_content %}


### PR DESCRIPTION
h.nav_named_link appears to have been removed 2 weeks ago with https://github.com/ckan/ckan/pull/2908

There was a previous effort to replace nav_named_link: https://github.com/ckan/ckanext-harvest/pull/224/files but it appears to have missed this one template.