### PR TITLE
Import dependencies in setup.py.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 recursive-include ckanext/harvest/templates *
 recursive-include ckanext/harvest/fanstatic_library/styles *
 recursive-include ckanext/harvest/public *
+include pip-requirements.txt
+include dev-requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -44,16 +44,12 @@ running a version lower than 2.0.
 
      (pyenv) $ pip install -e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext-harvest
 
-4. Install the python modules required by the extension::
-
-     (pyenv) $ pip install -r pip-requirements.txt
-
-5. Make sure the CKAN configuration ini file contains the harvest main plugin, as
+4. Make sure the CKAN configuration ini file contains the harvest main plugin, as
    well as the harvester for CKAN instances if you need it (included with the extension)::
 
      ckan.plugins = harvest ckan_harvester
 
-6. If you haven't done it yet on the previous step, define the backend that you
+5. If you haven't done it yet on the previous step, define the backend that you
    are using with the ``ckan.harvest.mq.type`` option (it defaults to ``amqp``)::
 
      ckan.harvest.mq.type = redis

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 factory-boy>=2
 mock
+nose

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,19 @@
 from setuptools import setup, find_packages
 import sys, os
+import codecs
+import os.path
 
 version = '0.2'
+
+# Read requirements from {pip,dev}-requirements.txt
+HERE = os.path.dirname(__file__)
+PIP_REQUIREMENTS_TXT = os.path.join(HERE, 'pip-requirements.txt')
+DEV_REQUIREMENTS_TXT = os.path.join(HERE, 'dev-requirements.txt')
+with codecs.open(PIP_REQUIREMENTS_TXT, encoding='utf8') as f:
+    install_requires = f.readlines()
+with codecs.open(DEV_REQUIREMENTS_TXT, encoding='utf8') as f:
+    tests_require = f.readlines()
+
 
 setup(
 	name='ckanext-harvest',
@@ -19,14 +31,8 @@ setup(
 	namespace_packages=['ckanext', 'ckanext.harvest'],
 	include_package_data=True,
 	zip_safe=False,
-	install_requires=[
-	        # dependencies are specified in pip-requirements.txt 
-	        # instead of here
-	],
-	tests_require=[
-		'nose',
-		'mock',
-	],
+	install_requires=install_requires,
+	tests_require=tests_require,
 	test_suite = 'nose.collector',
 	entry_points=\
 	"""


### PR DESCRIPTION
Currently, requirements are only listed in `pip-requirements.txt` and not in `setup.py`. Hence, after installing `ckanext-harvest` via `pip` one has to manually install the dependencies. This is described in the README, but people expect that `pip install ...` also installs dependencies. In addition, `setup.py` does list test requirements, but these differ from the ones listed in `dev-requirements.txt`.

This PR updates `setup.py` so that it automatically imports the list of packages required for installation and testing from `pip-requirements.txt` and `dev-requirements.txt`. This gives us DRY and `pip` users get what they expect.
