### PR TITLE
Send error mail to admin when harvesting fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,9 +190,7 @@ If you want to send Error-Mails when a Harvest-Job fails, you can set it up in p
 
     ckan.harvest.status_mail.errored = True
 
-The receiver(s) of the error-mails are configured in production.ini:
-
-    email_to = admin@your-portal.org, error-mails@your-portal.org
+That way, all CKAN-Users who are declared as Admins will receive the Error-Mails at their configured E-Mail-Address.
 
 If you don't specify this setting, the default will be False.
 

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,20 @@ or
 If you don't specify this setting, the default will be number-sequence.
 
 
+Send error mails when harvesting fails (optional)
+================================================
+
+If you want to send Error-Mails when a Harvest-Job fails, you can set it up in production.ini:
+
+    ckan.harvest.status_mail.errored = True
+
+The receiver(s) of the error-mails are configured in production.ini:
+
+    email_to = admin@your-portal.org, error-mails@your-portal.org
+
+If you don't specify this setting, the default will be False.
+
+
 Command line interface
 ======================
 

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -24,12 +24,14 @@ from ckan.logic import NotFound, check_access
 from ckanext.harvest.plugin import DATASET_TYPE_NAME
 from ckanext.harvest.queue import get_gather_publisher, resubmit_jobs
 
-from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
+from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject, HarvestObjectError, HarvestGatherError
 from ckanext.harvest.logic import HarvestJobExists
 from ckanext.harvest.logic.dictization import harvest_job_dictize
 
 from ckanext.harvest.logic.action.get import (
     harvest_source_show, harvest_job_list, _get_sources_for_user)
+
+import ckan.lib.mailer as mailer
 
 log = logging.getLogger(__name__)
 
@@ -549,6 +551,9 @@ def harvest_jobs_run(context, data_dict):
                     # status
                     get_action('harvest_source_reindex')(
                         context, {'id': job_obj.source.id})
+
+                    if toolkit.asbool(config.get('ckan.harvest.status_mail.errored')) and has_job_errors(context, job_obj):
+                        send_error_mail(context, job_obj)
                 else:
                     log.debug('Ongoing job:%s source:%s',
                               job['id'], job['source_id'])
@@ -557,6 +562,116 @@ def harvest_jobs_run(context, data_dict):
     resubmit_jobs()
 
     return []  # merely for backwards compatibility
+
+
+def has_job_errors(context, job_obj):
+    model = context['model']
+
+    harvest_object_error_count = model.Session.query(HarvestObjectError) \
+        .join(HarvestObject, HarvestObjectError.harvest_object_id == HarvestObject.harvest_job_id) \
+        .filter(HarvestObject.harvest_job_id == job_obj.id) \
+        .count()
+
+    harvest_gather_error_count = model.Session.query(HarvestGatherError) \
+        .filter(HarvestGatherError.harvest_job_id == job_obj.id) \
+        .count()
+
+    # if no error occurred we do not create the error-mail
+    if harvest_object_error_count == 0 and harvest_gather_error_count == 0:
+        return False
+
+    return True
+
+
+def send_error_mail(context, job_obj):
+    model = context['model']
+
+    for row in model.Session\
+            .query(model.Package)\
+            .filter(model.Package.id == job_obj.source.id):
+        pkg = row.as_dict()
+        harvest_name = str(pkg['name'])
+
+    ckan_site_url = config.get('ckan.site_url')
+    job_url = ckan_site_url + '/harvest/' + harvest_name + '/job/' + job_obj.id
+
+    msg = toolkit._('This is a failure-notification of the latest harvest job ({0}) set-up in {1}.').format(job_url, ckan_site_url)
+    msg += '\n\n'
+
+    for org, job in model.Session\
+            .query(model.Group, HarvestSource)\
+            .outerjoin(model.Member, model.Group) \
+            .join(HarvestSource, HarvestSource.id == model.Member.table_id) \
+            .filter(model.Member.table_id == job_obj.source.id):
+
+        if org:
+            org_dict = org.as_dict()
+            msg += toolkit._('Organization: {0}').format(org_dict['title'])
+            msg += '\n\n'
+
+        job_dict = job.as_dict()
+        msg += toolkit._('Harvest Job Title: {0}').format(job_dict['title'])
+        msg += '\n\n'
+
+    msg += toolkit._('Date of Harvest: {0}').format(str(job_obj.created))
+    msg += ' UTC\n\n'
+
+    out = {
+        'last_job': None,
+    }
+
+    out['last_job'] = harvest_job_dictize(job_obj, context)
+
+    msg += toolkit._('Records in Error: {0}').format(str(out['last_job']['stats'].get('errored', 0)))
+    msg += '\n'
+
+    obj_error = ''
+    job_error = ''
+
+
+    for harvest_object_error in model.Session.query(HarvestObjectError) \
+            .join(HarvestObject, HarvestObjectError.harvest_object_id == HarvestObject.harvest_job_id) \
+            .filter(HarvestObject.harvest_job_id == job_obj.id).limit(20).all():
+        error_dict = harvest_object_error.as_dict()
+        obj_error += error_dict['msg'] + '\n'
+
+    for harvest_gather_error in model.Session.query(HarvestGatherError) \
+        .filter(HarvestGatherError.harvest_job_id == job_obj.id):
+        harvest_gather_error_dict = harvest_gather_error.as_dict()
+        job_error += harvest_gather_error_dict['message'] + '\n'
+
+    if (obj_error != '' or job_error != ''):
+        msg += toolkit._('Error Summary')
+        msg += '\n\n'
+
+    if (obj_error != ''):
+        msg += toolkit._('Document Error')
+        msg += '\n' + obj_error + '\n\n'
+
+    if (job_error != ''):
+        msg += toolkit._('Job Errors')
+        msg += '\n' + job_error + '\n\n'
+
+    if obj_error or job_error:
+        msg += '\n--\n'
+        msg += toolkit._('You are receiving this email because you are currently set-up as Administrator for {0}. Please do not reply to this email as it was sent from a non-monitored address.').format(config.get('ckan.site_title'))
+
+        # get recipients
+        email_recipients = config.get('email_to').split(',')
+        emails = {}
+
+        for recipient in email_recipients:
+            email = {'recipient_name': recipient,
+                      'recipient_email': recipient,
+                      'subject': config.get('ckan.site_title') + ' - Harvesting Job - Error Notification',
+                      'body': msg}
+
+            log.debug(msg)
+
+            try:
+                mailer.mail_recipient(**email)
+            except:
+                log.error('Sending Harvest-Notification-Mail failed. Message: ' + msg)
 
 
 def harvest_send_job_to_gather_queue(context, data_dict):

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -556,10 +556,7 @@ def harvest_jobs_run(context, data_dict):
                     status = get_action('harvest_source_show_status')(context, {'id': job_obj.source.id})
 
                     if toolkit.asbool(config.get('ckan.harvest.status_mail.errored')) and (status['last_job']['stats']['errored']):
-                        try:
-                            send_error_mail(context, job_obj.source.id, status)
-                        except mailer.MailerException:
-                            pass
+                        send_error_mail(context, job_obj.source.id, status)
                 else:
                     log.debug('Ongoing job:%s source:%s',
                               job['id'], job['source_id'])
@@ -637,15 +634,11 @@ def send_error_mail(context, source_id, status):
 
             try:
                 mailer.mail_recipient(**email)
-                return True
             except mailer.MailerException:
                 log.error('Sending Harvest-Notification-Mail failed. Message: ' + msg)
-                raise mailer.MailerException
             except Exception as e:
                 log.error(e)
                 raise
-
-    return False
 
 
 def harvest_send_job_to_gather_queue(context, data_dict):

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -621,15 +621,16 @@ def send_error_mail(context, source_id, status):
         msg += '\n--\n'
         msg += toolkit._('You are receiving this email because you are currently set-up as Administrator for {0}. Please do not reply to this email as it was sent from a non-monitored address.').format(config.get('ckan.site_title'))
 
-        # get recipients
-        email_recipients = config.get('email_to').split(',')
-        emails = {}
+        model = context['model']
 
-        for recipient in email_recipients:
+        sysadmins = model.Session.query(model.User).filter(model.User.sysadmin == True).all()
+
+        # for recipient in email_recipients:
+        for recipient in sysadmins:
             email = {'recipient_name': recipient,
-                      'recipient_email': recipient,
-                      'subject': config.get('ckan.site_title') + ' - Harvesting Job - Error Notification',
-                      'body': msg}
+                     'recipient_email': recipient,
+                     'subject': config.get('ckan.site_title') + ' - Harvesting Job - Error Notification',
+                     'body': msg}
 
             log.debug(msg)
 

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -29,6 +29,10 @@ from ckan import model
 
 from ckanext.harvest.interfaces import IHarvester
 import ckanext.harvest.model as harvest_model
+from ckanext.harvest.model import HarvestGatherError, HarvestJob
+from ckanext.harvest.logic import HarvestJobExists
+from ckanext.harvest.logic.action.update import send_error_mail
+import ckan.lib.mailer as mailer
 
 
 def call_action_api(action, apikey=None, status=200, **kwargs):
@@ -559,7 +563,92 @@ class TestHarvestObject(unittest.TestCase):
         self.assertRaises(toolkit.ValidationError, harvest_object_create,
                           context, data_dict)
 
-          
+
+class TestHarvestErrorMail(unittest.TestCase):
+    @classmethod
+    def setup_class(cls):
+        reset_db()
+        harvest_model.setup()
+
+    def _create_harvest_source_and_job_if_not_existing(self):
+        site_user = toolkit.get_action('get_site_user')(
+            {'model': model, 'ignore_auth': True}, {})['name']
+
+        context = {
+            'user': site_user,
+            'model': model,
+            'session': model.Session,
+            'ignore_auth': True,
+        }
+        source_dict = {
+            'title': 'Test Source',
+            'name': 'test-source',
+            'url': 'basic_test',
+            'source_type': 'test',
+        }
+
+        try:
+            harvest_source = toolkit.get_action('harvest_source_create')(
+                context,
+                source_dict
+            )
+        except toolkit.ValidationError:
+            harvest_source = toolkit.get_action('harvest_source_show')(
+                context,
+                {'id': source_dict['name']}
+            )
+            pass
+
+        try:
+            job = toolkit.get_action('harvest_job_create')(context, {
+                'source_id': harvest_source['id'], 'run': True})
+        except HarvestJobExists:
+            job = toolkit.get_action('harvest_job_show')(context, {
+                'id': harvest_source['status']['last_job']['id']})
+            pass
+
+        toolkit.get_action('harvest_jobs_run')(context, {})
+        toolkit.get_action('harvest_source_reindex')(context, {'id': harvest_source['id']})
+        return context, harvest_source, job
+
+    def test_error_mail_not_sent(self):
+        context, harvest_source, job = self._create_harvest_source_and_job_if_not_existing()
+
+        status = toolkit.get_action('harvest_source_show_status')(context, {'id': harvest_source['id']})
+
+        error_mail_sent = send_error_mail(
+            context,
+            harvest_source['id'],
+            status
+        )
+        assert_equal(0, status['last_job']['stats']['errored'])
+        assert_equal(False, error_mail_sent)
+
+    def test_error_mail_sent(self):
+        context, harvest_source, job = self._create_harvest_source_and_job_if_not_existing()
+
+        # create a HarvestGatherError
+        job_model = HarvestJob.get(job['id'])
+        msg = 'System error - No harvester could be found for source type %s' % job_model.source.type
+        err = HarvestGatherError(message=msg, job=job_model)
+        err.save()
+
+        status = toolkit.get_action('harvest_source_show_status')(context, {'id': harvest_source['id']})
+
+        # if we receive a Mailer-Exception we mark this test as skipped
+        try:
+            error_mail_sent = send_error_mail(
+                context,
+                harvest_source['id'],
+                status
+            )
+        except mailer.MailerException:
+            raise SkipTest()
+
+        assert_equal(1, status['last_job']['stats']['errored'])
+        assert_equal(True, error_mail_sent)
+
+
 class TestHarvestDBLog(unittest.TestCase):
     @classmethod
     def setup_class(cls):

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -564,11 +564,17 @@ class TestHarvestObject(unittest.TestCase):
                           context, data_dict)
 
 
-class TestHarvestErrorMail(unittest.TestCase):
+class TestHarvestErrorMail(FunctionalTestBase):
     @classmethod
     def setup_class(cls):
+        super(TestHarvestErrorMail, cls).setup_class()
         reset_db()
         harvest_model.setup()
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestHarvestErrorMail, cls).teardown_class()
+        reset_db()
 
     def _create_harvest_source_and_job_if_not_existing(self):
         site_user = toolkit.get_action('get_site_user')(


### PR DESCRIPTION
This fixes https://github.com/ckan/ckanext-harvest/issues/185

I integrated a part of the https://github.com/GSA/ckanext-harvest solution into the ckanext-harvest-module.

To use it, configure the needed configuration values: 
**ckan.harvest.status_mail.errored = true**
email_to = %a comma seperated list of people to receive the error notification-mails%
error_email_from = %email-adress of sender%
ckan.site_title = %name of your site, so receivers know who you are%

How it works:
After being done with harvesting, the harvest_object-table will be checked for errors and the e-mail is generated accordingly. While the GSA-module sends an email after every harvesting-job about all states (added, updated, deleted) this only takes 'errored' into consideration.
