### PR TITLE
Fix default_groups, plus fix docs for default_tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,7 +289,8 @@ field. The currently supported configuration options are:
     the CKAN API. Default is 2.
 
 *   default_tags: A list of tags that will be added to all harvested datasets.
-    Tags don't need to previously exist.
+    Tags don't need to previously exist. This field takes a list of tag dicts
+    (see example), which allows you to optinally specify a vocabulary.
 
 *   default_groups: A list of groups to which the harvested datasets will be
     added to. The groups must exist. Note that you must use ids or names to
@@ -367,7 +368,7 @@ the configuration field)::
 
     {
      "api_version": 1,
-     "default_tags":["new-tag-1","new-tag-2"],
+     "default_tags": [{"name": "geo"}, {"name": "namibia"],
      "default_groups":["my-own-group"],
      "default_extras":{"new_extra":"Test","harvest_url":"{harvest_source_url}/dataset/{dataset_id}"},
      "override_extras": true,

--- a/README.rst
+++ b/README.rst
@@ -368,7 +368,7 @@ the configuration field)::
      "api_version": 1,
      "default_tags": [{"name": "geo"}, {"name": "namibia"],
      "default_groups": ["science", "spend-data"],
-     "default_extras":{"new_extra":"Test","harvest_url":"{harvest_source_url}/dataset/{dataset_id}"},
+     "default_extras": {"encoding":"utf8", "harvest_url": "{harvest_source_url}/dataset/{dataset_id}"},
      "override_extras": true,
      "organizations_filter_include": [],
      "organizations_filter_exclude": ["remote-organization"],

--- a/README.rst
+++ b/README.rst
@@ -292,10 +292,8 @@ field. The currently supported configuration options are:
     Tags don't need to previously exist. This field takes a list of tag dicts
     (see example), which allows you to optinally specify a vocabulary.
 
-*   default_groups: A list of groups to which the harvested datasets will be
-    added to. The groups must exist. Note that you must use ids or names to
-    define the groups according to the API version you defined (names for version
-    1, ids for version 2).
+*   default_groups: A list of group IDs or names to which the harvested datasets
+    will be added to. The groups must exist.
 
 *   default_extras: A dictionary of key value pairs that will be added to extras
     of the harvested datasets. You can use the following replacement strings,
@@ -369,7 +367,7 @@ the configuration field)::
     {
      "api_version": 1,
      "default_tags": [{"name": "geo"}, {"name": "namibia"],
-     "default_groups":["my-own-group"],
+     "default_groups": ["science", "spend-data"],
      "default_extras":{"new_extra":"Test","harvest_url":"{harvest_source_url}/dataset/{dataset_id}"},
      "override_extras": true,
      "organizations_filter_include": [],

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -121,6 +121,10 @@ class CKANHarvester(HarvesterBase):
             if 'default_tags' in config_obj:
                 if not isinstance(config_obj['default_tags'], list):
                     raise ValueError('default_tags must be a list')
+                if config_obj['default_tags'] and \
+                        not isinstance(config_obj['default_tags'][0], dict):
+                    raise ValueError('default_tags must be a list of '
+                                     'dictionaries')
 
             if 'default_groups' in config_obj:
                 if not isinstance(config_obj['default_groups'], list):

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -221,3 +221,23 @@ class TestCkanHarvester(object):
             harvester=CKANHarvester())
         assert not results_by_guid
         assert not was_last_job_considered_error_free()
+
+    def test_default_tags(self):
+        config = {'default_tags': [{'name': 'geo'}]}
+        results_by_guid = run_harvest(
+            url='http://localhost:%s' % mock_ckan.PORT,
+            harvester=CKANHarvester(),
+            config=json.dumps(config))
+        tags = results_by_guid['dataset1-id']['dataset']['tags']
+        tag_names = [tag['name'] for tag in tags]
+        assert 'geo' in tag_names
+
+    def test_default_tags_invalid(self):
+        config = {'default_tags': ['geo']}  # should be list of dicts
+        assert_raises(
+            run_harvest,
+            url='http://localhost:%s' % mock_ckan.PORT,
+            harvester=CKANHarvester(),
+            config=json.dumps(config))
+
+

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -4,6 +4,7 @@ from nose.tools import assert_equal, assert_raises
 import json
 from mock import patch, MagicMock
 
+
 try:
     from ckan.tests.helpers import reset_db, call_action
     from ckan.tests.factories import Organization, Group
@@ -240,4 +241,40 @@ class TestCkanHarvester(object):
             harvester=CKANHarvester(),
             config=json.dumps(config))
 
+    def test_default_groups(self):
+        Group(id='group1-id', name='group1')
+        Group(id='group2-id', name='group2')
+        Group(id='group3-id', name='group3')
+
+        config = {'default_groups': ['group2-id', 'group3'],
+                  'remote_groups': 'only_local'}
+        tmp_c = toolkit.c
+        try:
+            # c.user is used by the validation (annoying),
+            # however patch doesn't work because it's a weird
+            # StackedObjectProxy, so we swap it manually
+            toolkit.c = MagicMock(user='')
+            results_by_guid = run_harvest(
+                url='http://localhost:%s' % mock_ckan.PORT,
+                harvester=CKANHarvester(),
+                config=json.dumps(config))
+        finally:
+            toolkit.c = tmp_c
+        assert_equal(results_by_guid['dataset1-id']['errors'], [])
+        groups = results_by_guid['dataset1-id']['dataset']['groups']
+        group_names = set(group['name'] for group in groups)
+        # group1 comes from the harvested dataset
+        # group2 & 3 come from the default_groups
+        assert_equal(group_names, set(('group1', 'group2', 'group3')))
+
+    def test_default_groups_invalid(self):
+        Group(id='group2-id', name='group2')
+
+        # should be list of strings
+        config = {'default_tags': [{'name': 'group2'}]}
+        assert_raises(
+            run_harvest,
+            url='http://localhost:%s' % mock_ckan.PORT,
+            harvester=CKANHarvester(),
+            config=json.dumps(config))
 

--- a/ckanext/harvest/tests/lib.py
+++ b/ckanext/harvest/tests/lib.py
@@ -10,7 +10,8 @@ def run_harvest(url, harvester, config=''):
     Queues are avoided as they are a pain in tests.
     '''
     # User creates a harvest source
-    source = HarvestSourceObj(url=url, config=config)
+    source = HarvestSourceObj(url=url, config=config,
+                              source_type=harvester.info()['name'])
 
     # User triggers a harvest, which is the creation of a harvest job.
     # We set run=False so that it doesn't put it on the gather queue.

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
 	ckan_harvester=ckanext.harvest.harvesters:CKANHarvester
     [ckan.test_plugins]
 	test_harvester=ckanext.harvest.tests.test_queue:MockHarvester
+	test_harvester2=ckanext.harvest.tests.test_queue2:MockHarvester
 	test_action_harvester=ckanext.harvest.tests.test_action:MockHarvesterForActionTests
 	[paste.paster_command]
 	harvester = ckanext.harvest.commands.harvester:Harvester

--- a/test-core.ini
+++ b/test-core.ini
@@ -15,7 +15,7 @@ port = 5000
 use = config:../ckan/test-core.ini
 # Here we hard-code the database and a flag to make default tests
 # run fast.
-ckan.plugins = harvest ckan_harvester test_harvester test_action_harvester
+ckan.plugins = harvest ckan_harvester test_harvester test_harvester2 test_action_harvester
 ckan.harvest.mq.type = redis
 ckan.legacy_templates = false
 # NB: other test configuration should go in test-core.ini, which is


### PR DESCRIPTION
Previously, default_groups caused an exception on package_update - this is now fixed.

Previously, default_tags was documented as taking a list of tag strings and now it is fixed to be a list of tag dicts.

I also added more validation and tests for these, plus default_extras which appeared to be fine.

Fixes #249