### PR TITLE
Fixes default_groups

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -128,7 +128,7 @@ class CKANHarvester(HarvesterBase):
                     raise ValueError('default_groups must be a *list* of group'
                                      ' names/ids')
                 if config_obj['default_groups'] and \
-                        not isinstance(config_obj['default_groups'][0], str):
+                        not isinstance(config_obj['default_groups'][0], basestring):
                     raise ValueError('default_groups must be a list of group '
                                      'names/ids (i.e. strings)')
 
@@ -492,9 +492,15 @@ class CKANHarvester(HarvesterBase):
             # Set default groups if needed
             default_groups = self.config.get('default_groups', [])
             if default_groups:
+                context = {'model': model, 'user': toolkit.c.user}
                 if not 'groups' in package_dict:
                     package_dict['groups'] = []
                 existing_group_ids = [g['id'] for g in package_dict['groups']]
+                self.default_group_dicts = []
+                for group_name_or_id in default_groups:
+                        group = get_action('group_show')(
+                            context, {'id': group_name_or_id})
+                        self.default_group_dicts.append(group)
                 package_dict['groups'].extend(
                     [g for g in self.default_group_dicts
                      if g['id'] not in existing_group_ids])


### PR DESCRIPTION
Fixes #253

This fixes the two interconnected issues where perfectly normal "default_groups" parameters were failing - both at the validation stage and the import stage.

The fix at the validation stage simply involves changing the type from a string to a basestring as David Read suggested.

The fix at the import stage was because it couldn't find the self.default_group_dicts variable that was being referenced. I made it available and populated it from the default groups variable already defined on line 493.

It works great for me now and I've tested this fix on two separate servers. Cheers!