### PR TITLE
[#253] Fix default_groups

### DIFF
--- a/ckanext/harvest/logic/validators.py
+++ b/ckanext/harvest/logic/validators.py
@@ -134,12 +134,14 @@ def harvest_source_config_validator(key, data, errors, context):
         if info['name'] == harvester_type:
             if hasattr(harvester, 'validate_config'):
                 try:
-                    return harvester.validate_config(data[key])
+                    config = harvester.validate_config(data[key])
                 except Exception, e:
                     raise Invalid('Error parsing the configuration options: %s'
                                   % e)
-            else:
-                return data[key]
+                if config is not None:
+                    # save an edited config, for use during the harvest
+                    data[key] = config
+            # no value is returned for this sort of validator/converter
 
 
 def keep_not_empty_extras(key, data, errors, context):


### PR DESCRIPTION
Saves the group dicts to the config object. Because saving them to the harvester object doesn't work in the real world (although it did in the tests).

Saving the group dicts up-front in a harvest is a lot more efficient than doing group_show for every dataset imported.

Also allow default_groups to be a list of *unicode* strings. I don't know how that would happen, but coping with this user's problem is no trouble.