### PR TITLE
[#257] Purge only our own Redis data.

### DIFF
--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -65,9 +65,7 @@ class Harvester(CkanCommand):
 
       harvester purge_queues
         - removes all jobs from fetch and gather queue
-          WARNING: if using Redis, this command purges all data in the current
-          Redis database
-          
+
       harvester clean_harvest_log
         - Clean-up mechanism for the harvest log table.
           You can configure the time frame through the configuration


### PR DESCRIPTION
Fixes #257.

Previously purging the queue on the Redis backend would clear the whole database, making it hard to share the same database with other parts of CKAN. With this commit, only the keys that belong to ckanext-harvest and the current CKAN instance are purged.