### PR TITLE
Add new parameter return_last_job_status to harvest_source_list

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -130,7 +130,7 @@ def harvest_source_list(context, data_dict):
 
     sources = _get_sources_for_user(context, data_dict)
 
-    last_job_status = data_dict.get('return_last_job_status', False)
+    last_job_status = p.toolkit.asbool(data_dict.get('return_last_job_status', False))
 
     return [harvest_source_dictize(source, context, last_job_status) for source in sources]
 

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -130,7 +130,9 @@ def harvest_source_list(context, data_dict):
 
     sources = _get_sources_for_user(context, data_dict)
 
-    return [harvest_source_dictize(source, context) for source in sources]
+    last_job_status = data_dict.get('return_last_job_status', False)
+
+    return [harvest_source_dictize(source, context, last_job_status) for source in sources]
 
 
 @side_effect_free

--- a/ckanext/harvest/logic/dictization.py
+++ b/ckanext/harvest/logic/dictization.py
@@ -1,15 +1,12 @@
 from sqlalchemy import distinct, func
 
 from ckan.model import Package, Group
+from ckan import logic
 from ckanext.harvest.model import (HarvestSource, HarvestJob, HarvestObject,
                                    HarvestGatherError, HarvestObjectError)
 
 
-def harvest_source_dictize(source, context):
-    '''
-    TODO: Deprecated
-    '''
-
+def harvest_source_dictize(source, context, last_job_status=False):
     out = source.as_dict()
 
     out['publisher_title'] = u''
@@ -21,6 +18,10 @@ def harvest_source_dictize(source, context):
             out['publisher_title'] = group.title
 
     out['status'] = _get_source_status(source, context)
+
+    if last_job_status:
+        source_status = logic.get_action('harvest_source_show_status')(context, {'id': source.id})
+        out['last_job_status'] = source_status.get('last_job', {})
 
     return out
 


### PR DESCRIPTION
In order to get a quick overview over successful/failed harvesters, a
call to `harvest_source_list` with `return_last_job_status=true` can be used
to get this information.
By default `return_last_job_status` is `False`, and hence the extra
resources to grab this information is not wasted for every call, but
only if the client requests is explicitly.
The original `status` field stays as-is, this PR introduces a new field
called `last_job_status` to return this information.

The returned information is gathered by a call to
`harvest_source_status_show`.