### PR TITLE
Include i18n directory in package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,6 @@
+Changelog
+=========
+
+v0.0.6 `2016-??-??`
+-------------------
+Includes i18n directory in package.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include ckanext/harvest/templates *
 recursive-include ckanext/harvest/fanstatic_library/styles *
 recursive-include ckanext/harvest/public *
+recursive-include ckanext/harvest/i18n *


### PR DESCRIPTION
Keeps the `ckanext/harvest/i18n` directory.