### PR TITLE
remove authz as they are not used and they are no longer new

### DIFF
--- a/ckanext/harvest/controllers/organization.py
+++ b/ckanext/harvest/controllers/organization.py
@@ -6,7 +6,6 @@ from ckan.lib.base import c, model, request, render, h, g
 from ckan.lib.base import abort
 import ckan.lib.maintain as maintain
 import ckan.lib.search as search
-import ckan.new_authz
 
 from ckan.controllers.group import GroupController
 


### PR DESCRIPTION
Ckan 2.6 dropped new_authz and they are not needed.