### PR TITLE
Fix setup.py to match it's current paster template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
 	url='http://ckan.org/wiki/Extensions',
 	license='AGPL',
 	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext', 'ckanext.harvest'],
+	namespace_packages=['ckanext'],
 	include_package_data=True,
 	zip_safe=False,
 	install_requires=[


### PR DESCRIPTION
Fixes plugin's setup.py namespace_packages to match the updated setup.py paster template. Fixes the issue mentioned in e.g. here: https://github.com/ckan/ckan/issues/2893