### PR TITLE
Abort stuck harvest jobs through UI

### DIFF
--- a/ckanext/harvest/controllers/view.py
+++ b/ckanext/harvest/controllers/view.py
@@ -195,6 +195,23 @@ class ViewController(BaseController):
             abort(404,_('Harvest source not found'))
         except p.toolkit.NotAuthorized:
             abort(401,self.not_auth_message)
+                
+    def abort_job(self, source, id):
+        try:
+            context = {'model':model, 'user':c.user}
+            c.job = p.toolkit.get_action('harvest_job_abort')(context, {'id': id})
+            c.harvest_source = p.toolkit.get_action('harvest_source_show')(context, {'id': source})
+            h.flash_success(_('Harvest job stopped'))
+            
+        except p.toolkit.ObjectNotFound:
+            abort(404,_('Harvest job not found'))
+        except p.toolkit.NotAuthorized:
+            abort(401,self.not_auth_message)
+        except Exception, e:
+            msg = 'An error occurred: [%s]' % str(e)
+            abort(500,msg)
+            
+        h.redirect_to(h.url_for('{0}_admin'.format(DATASET_TYPE_NAME), id=source))
 
     def show_last_job(self, source):
 

--- a/ckanext/harvest/plugin.py
+++ b/ckanext/harvest/plugin.py
@@ -240,6 +240,7 @@ class Harvest(p.SingletonPlugin, DefaultDatasetForm, DefaultTranslation):
         map.connect('harvest_job_list', '/' + DATASET_TYPE_NAME + '/{source}/job', controller=controller, action='list_jobs')
         map.connect('harvest_job_show_last', '/' + DATASET_TYPE_NAME + '/{source}/job/last', controller=controller, action='show_last_job')
         map.connect('harvest_job_show', '/' + DATASET_TYPE_NAME + '/{source}/job/{id}', controller=controller, action='show_job')
+        map.connect('harvest_job_abort', '/' + DATASET_TYPE_NAME + '/{source}/job/{id}/abort', controller=controller, action='abort_job')
 
         map.connect('harvest_object_show', '/' + DATASET_TYPE_NAME + '/object/:id', controller=controller, action='show_object')
         map.connect('harvest_object_for_dataset_show', '/dataset/harvest_object/:id', controller=controller, action='show_object', ref_type='dataset')

--- a/ckanext/harvest/templates/source/admin.html
+++ b/ckanext/harvest/templates/source/admin.html
@@ -6,12 +6,6 @@
     {% if source.status and source.status.last_job %}
       {% snippet "snippets/job_details.html", job=source.status.last_job %}
       <div class="form-actions">
-        {% if source.status and source.status.last_job and (source.status.last_job.status == 'Running') %}
-        <a href="{{ h.url_for('harvest_job_abort', source=source.name, id=source.status.last_job.id) }}" class="btn" title="Stop this Job">
-          <i class="icon-ban-circle"></i>
-          {{ _('Stop') }}
-        </a>
-        {% endif %}
         <a href="{{ h.url_for(controller='ckanext.harvest.controllers.view:ViewController', action='show_last_job', source=source.name) }}" class="btn pull-right">
           <i class="icon-briefcase"></i>
           {{ _('View full job report')  }}

--- a/ckanext/harvest/templates/source/admin.html
+++ b/ckanext/harvest/templates/source/admin.html
@@ -6,6 +6,12 @@
     {% if source.status and source.status.last_job %}
       {% snippet "snippets/job_details.html", job=source.status.last_job %}
       <div class="form-actions">
+        {% if source.status and source.status.last_job and (source.status.last_job.status == 'Running') %}
+        <a href="{{ h.url_for('harvest_job_abort', source=source.name, id=source.status.last_job.id) }}" class="btn" title="Stop this Job">
+          <i class="icon-ban-circle"></i>
+          {{ _('Stop') }}
+        </a>
+        {% endif %}
         <a href="{{ h.url_for(controller='ckanext.harvest.controllers.view:ViewController', action='show_last_job', source=source.name) }}" class="btn pull-right">
           <i class="icon-briefcase"></i>
           {{ _('View full job report')  }}

--- a/ckanext/harvest/templates/source/admin_base.html
+++ b/ckanext/harvest/templates/source/admin_base.html
@@ -21,6 +21,14 @@
       </a>
     {{ '</li>' if show_li }}
   {% endif %}
+  {% if source.status and source.status.last_job and (source.status.last_job.status == 'Running') %}
+    {{ '<li>' if show_li }}
+      <a href="{{ h.url_for('harvest_job_abort', source=source.name, id=source.status.last_job.id) }}" class="btn" title="Stop this Job">
+        <i class="icon-ban-circle"></i>
+        {{ _('Stop') }}
+      </a>
+    {{ '</li>' if show_li }}
+  {% endif %}
     {% set locale = h.dump_json({'content': _('Warning: This will remove all datasets for this source, as well as all previous job reports. Are you sure you want to continue?')}) %}
     {{ '<li>' if show_li }}
       <a href="{{ h.url_for('harvest_clear', id=source.id) }}" class="btn" data-module="confirm-action" data-module-i18n="{{ locale }}"


### PR DESCRIPTION
Occasionally harvester will get stuck at `Running` state (limbo) if it fails without proper error handling  and once it does the only way to restore harvester is either abort the job from CLI or the `Clear` option from UI. 

This PR provides UI for aborting limbo jobs without requiring to log into the server or clear the source altogether.

Relates to: #112 