### PR TITLE
Use the package_search API for the count of datasets

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -61,6 +61,17 @@ def package_list_for_source(source_id):
 
     return out
 
+def package_count_for_source(source_id):
+    '''
+    Returns the current package count for datasets associated with the given
+    source id
+    '''
+    fq = 'harvest_source_id:"{0}"'.format(source_id)
+    search_dict = {'fq': fq}
+    context = {'model': model, 'session': model.Session}
+    result = logic.get_action('package_search')(context, search_dict)
+    return result.get('count', 0)
+
 def harvesters_info():
     context = {'model': model, 'user': p.toolkit.c.user or p.toolkit.c.author}
     return logic.get_action('harvesters_info_show')(context,{})

--- a/ckanext/harvest/plugin.py
+++ b/ckanext/harvest/plugin.py
@@ -286,6 +286,7 @@ class Harvest(p.SingletonPlugin, DefaultDatasetForm, DefaultTranslation):
         from ckanext.harvest import helpers as harvest_helpers
         return {
                 'package_list_for_source': harvest_helpers.package_list_for_source,
+                'package_count_for_source': harvest_helpers.package_count_for_source,
                 'harvesters_info': harvest_helpers.harvesters_info,
                 'harvester_types': harvest_helpers.harvester_types,
                 'harvest_frequencies': harvest_helpers.harvest_frequencies,

--- a/ckanext/harvest/templates/source/read_base.html
+++ b/ckanext/harvest/templates/source/read_base.html
@@ -26,10 +26,8 @@
       {% endif %}
       <div class="nums">
         <dl>
-        {% if c.harvest_source.status %}
             <dt>{{ _('Datasets') }}</dt>
-            <dd>{{ c.harvest_source.status.total_datasets }}</dd>
-        {% endif %}
+            <dd>{{ h.package_count_for_source(c.harvest_source.id) }}</dd>
         </dl>
       </div>
     </section>


### PR DESCRIPTION
Rather than relying on the 'current' flag on the HarvestObject it's more
accuarte to use the package_search API to display the current number of
datasets, as this is actually the number of datasets displayed in the
list.
If for whatever reason the 'current' flag is not up-to-date, this leads
to a mismatch between the displayed number of datasets and the acutal
number of datasets returned by CKAN.