### PR TITLE
Catch DatabaseError in fetch/gather callbacks

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -274,9 +274,10 @@ def gather_callback(channel, method, header, body):
 
     try:
         job = HarvestJob.get(id)
-    except sqlalchemy.exc.OperationalError:
+    except sqlalchemy.exc.DatabaseError:
         # Occasionally we see: sqlalchemy.exc.OperationalError
         # "SSL connection has been closed unexpectedly"
+        # or DatabaseError "connection timed out"
         log.exception('Connection Error during gather of job %s', id)
         # By not sending the ack, it will be retried later.
         # Try to clear the issue with a remove.
@@ -374,9 +375,10 @@ def fetch_callback(channel, method, header, body):
 
     try:
         obj = HarvestObject.get(id)
-    except sqlalchemy.exc.OperationalError:
+    except sqlalchemy.exc.DatabaseError:
         # Occasionally we see: sqlalchemy.exc.OperationalError
         # "SSL connection has been closed unexpectedly"
+        # or DatabaseError "connection timed out"
         log.exception('Connection Error during fetch of job %s', id)
         # By not sending the ack, it will be retried later.
         # Try to clear the issue with a remove.

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -274,12 +274,10 @@ def gather_callback(channel, method, header, body):
 
     try:
         job = HarvestJob.get(id)
-    except sqlalchemy.exc.OperationalError, e:
+    except sqlalchemy.exc.OperationalError:
         # Occasionally we see: sqlalchemy.exc.OperationalError
         # "SSL connection has been closed unexpectedly"
-        log.exception(e)
-        log.error('Connection Error during gather of job %s: %r %r',
-                  id, e, e.args)
+        log.exception('Connection Error during gather of job %s', id)
         # By not sending the ack, it will be retried later.
         # Try to clear the issue with a remove.
         model.Session.remove()
@@ -376,12 +374,10 @@ def fetch_callback(channel, method, header, body):
 
     try:
         obj = HarvestObject.get(id)
-    except sqlalchemy.exc.OperationalError, e:
+    except sqlalchemy.exc.OperationalError:
         # Occasionally we see: sqlalchemy.exc.OperationalError
         # "SSL connection has been closed unexpectedly"
-        log.exception(e)
-        log.error('Connection Error during gather of harvest object %s: %r %r',
-                  id, e, e.args)
+        log.exception('Connection Error during fetch of job %s', id)
         # By not sending the ack, it will be retried later.
         # Try to clear the issue with a remove.
         model.Session.remove()


### PR DESCRIPTION
I occasionally get the following errors on a production server:
```
  File "/home/opendata/src/ckanext-harvest/ckanext/harvest/commands/harvester.py", line 183,
 in command
    gather_callback(consumer, method, header, body)
  File "/home/opendata/src/ckanext-harvest/ckanext/harvest/queue.py", line 276, in gather_ca
llback
    job = HarvestJob.get(id)
  File "/home/opendata/src/ckanext-harvest/ckanext/harvest/model/__init__.py", line 118, in
get
    o = cls.filter(**kwds).first()
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2334,
 in first
    ret = list(self[0:1])
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2201,
 in __getitem__
    return list(res)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2405,
 in __iter__
    return self._execute_and_instances(context)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2420,
 in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 727
, in execute
    return meth(self, multiparams, params)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/sql/elements.py", line 32
2, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 824
, in _execute_clauseelement
    compiled_sql, distilled_params
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 954
, in _execute_context
    context)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 111
6, in _handle_dbapi_exception
    exc_info
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/util/compat.py", line 189
, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/engine/base.py", line 947
, in _execute_context
    context)
  File "/home/opendata/venv/lib/python2.7/site-packages/sqlalchemy/engine/default.py", line 435, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.DatabaseError: (DatabaseError) could not receive data from server: Connection timed out
```
This makes respective harvest jobs going in "limbo".

So in this PR (second commit) I changed the `except sqlalchemy.exc.OperationalError` into `except sqlalchemy.exc.DatabaseError` (the latter exception class being a superclass of the former).

Along the way, the first commit just cleans up the logging logic.