### PR TITLE
Move _last_error_free_job from CKANHarvester to HarvesterBase

### DIFF
--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -18,6 +18,7 @@ from ckanext.harvest.tests.factories import (HarvestSourceObj, HarvestJobObj,
                                              HarvestObjectObj)
 from ckanext.harvest.tests.lib import run_harvest
 import ckanext.harvest.model as harvest_model
+from ckanext.harvest.harvesters.base import HarvesterBase
 from ckanext.harvest.harvesters.ckanharvester import CKANHarvester
 
 import mock_ckan
@@ -33,7 +34,7 @@ def was_last_job_considered_error_free():
     job = MagicMock()
     job.source = last_job.source
     job.id = ''
-    return bool(CKANHarvester._last_error_free_job(job))
+    return bool(HarvesterBase.last_error_free_job(job))
 
 
 class TestCkanHarvester(object):


### PR DESCRIPTION
* Since CKANHarvester._last_error_free_job is such a useful method for any kind of harvester, this PR moves it to HarvesterBase.
* Method signature is changed from _last_error_free_job to last_error_free_job to make it part of the API of HarvesterBase (rather then an internal method).
* All occurrences of _last_error_free_job have been adjusted.