### PR TITLE
Remove returning stored site user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ services:
 install:
     - bash bin/travis-build.bash
 script: sh bin/travis-run.sh
+
+# the new trusty images of Travis cause build errors with psycopg2, see https://github.com/travis-ci/travis-ci/issues/8897
+dist: trusty
+group: deprecated-2017Q4

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -169,9 +169,6 @@ class HarvesterBase(SingletonPlugin):
            ckanext.harvest.user_name = harvest
 
         '''
-        if self._user_name:
-            return self._user_name
-
         config_user_name = config.get('ckanext.harvest.user_name')
         if config_user_name:
             self._user_name = config_user_name


### PR DESCRIPTION
Site user is lost when validation fail during package_create.

This might fix #151.