### PR TITLE
Validate dataset before create or update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ services:
 install:
     - bash bin/travis-build.bash
 script: sh bin/travis-run.sh
+
+# the new trusty images of Travis cause build errors with psycopg2, see https://github.com/travis-ci/travis-ci/issues/8897
+dist: trusty
+group: deprecated-2017Q4

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -9,6 +9,7 @@ from ckan.logic import ValidationError, NotFound, get_action
 from ckan.lib.helpers import json
 from ckan.lib.munge import munge_name
 from ckan.plugins import toolkit
+import ckan.lib.plugins as lib_plugins
 
 from ckanext.harvest.model import HarvestObject
 
@@ -527,6 +528,17 @@ class CKANHarvester(HarvesterBase):
                 # and saving it will cause an IntegrityError with the foreign
                 # key.
                 resource.pop('revision_id', None)
+
+
+            package_plugin = lib_plugins.lookup_package_plugin('dataset')
+            schema = package_plugin.create_package_schema()
+
+            context = {}
+            data, errors = lib_plugins.plugin_validate(
+                package_plugin, context, package_dict, schema, 'package_create')
+
+            if errors:
+                raise ValidationError(errors)
 
             result = self._create_or_update_package(
                 package_dict, harvest_object, package_dict_form='package_show')


### PR DESCRIPTION
Attempt number 2 to fix #151.

Dataset is now validated before it is given to the baseharvester, if there is validation error it is raised again to store it to the harvester log.