### PR TITLE
FontAwesome 4.x/CKAN 2.7.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ services:
 install:
     - bash bin/travis-build.bash
 script: sh bin/travis-run.sh
+
+# the new trusty images of Travis cause build errors with psycopg2, see https://github.com/travis-ci/travis-ci/issues/8897
+dist: trusty
+group: deprecated-2017Q4

--- a/ckanext/harvest/templates/snippets/add_source_button.html
+++ b/ckanext/harvest/templates/snippets/add_source_button.html
@@ -2,7 +2,7 @@
 
 {% if authorized_user %}
   <a href="{{ h.url_for('{0}_new'.format(dataset_type)) }}" class="btn btn-primary">
-    <i class="icon-plus-sign-alt"></i>
+    <i class="fa fa-plus-square icon-plus-sign-alt"></i>
       {{ _('Add Harvest Source') }}
   </a>
 {% endif %}

--- a/ckanext/harvest/templates/source/admin.html
+++ b/ckanext/harvest/templates/source/admin.html
@@ -7,7 +7,7 @@
       {% snippet "snippets/job_details.html", job=source.status.last_job %}
       <div class="form-actions">
         <a href="{{ h.url_for(controller='ckanext.harvest.controllers.view:ViewController', action='show_last_job', source=source.name) }}" class="btn pull-right">
-          <i class="icon-briefcase"></i>
+          <i class="fa fa-briefcase icon-briefcase"></i>
           {{ _('View full job report')  }}
         </a>
       </div>

--- a/ckanext/harvest/templates/source/admin_base.html
+++ b/ckanext/harvest/templates/source/admin_base.html
@@ -10,13 +10,13 @@
 {% block action_links %}
   {% set show_li = c.__version__.startswith('2.0') %}
   {% if source.status and source.status.last_job and (source.status.last_job.status == 'New' or source.status.last_job.status == 'Running') %}
-    {{ '<li>' if show_li }}<a class="btn disabled" rel="tooltip" title="There already is an unrun job for this source"><i class="icon-refresh icon-large"></i> Reharvest</a>{{ '</li>' if show_li }}
+    {{ '<li>' if show_li }}<a class="btn disabled" rel="tooltip" title="There already is an unrun job for this source"><i class="fa fa-lg fa-refresh icon-refresh icon-large"></i> Reharvest</a>{{ '</li>' if show_li }}
   {% else %}
     {% set locale = h.dump_json({'content': _('This will re-run the harvesting for this source. Any updates at the source will overwrite the local datasets. Sources with a large number of datasets may take a significant amount of time to finish harvesting. Please confirm you would like us to start reharvesting.')}) %}
     {{ '<li>' if show_li }}
       <a href="{{ h.url_for('harvest_refresh', id=source.id) }}" class="btn" data-module="confirm-action" data-module-i18n="{{ locale }}"
          title="{{ _('Start a new harvesting job for this harvest source now') }}">
-        <i class="icon-refresh"></i>
+        <i class="fa fa-refresh icon-refresh"></i>
         {{ _('Reharvest') }}
       </a>
     {{ '</li>' if show_li }}
@@ -24,7 +24,7 @@
   {% if source.status and source.status.last_job and (source.status.last_job.status == 'Running') %}
     {{ '<li>' if show_li }}
       <a href="{{ h.url_for('harvest_job_abort', source=source.name, id=source.status.last_job.id) }}" class="btn" title="Stop this Job">
-        <i class="icon-ban-circle"></i>
+        <i class="fa fa-ban icon-ban-circle"></i>
         {{ _('Stop') }}
       </a>
     {{ '</li>' if show_li }}

--- a/ckanext/harvest/templates/source/new.html
+++ b/ckanext/harvest/templates/source/new.html
@@ -25,7 +25,7 @@
 
 {% block secondary_content %}
   <section class="module module-narrow">
-    <h2 class="module-heading"><i class="icon-large icon-info-sign"></i> {{ _('Harvest sources') }}</h2>
+    <h2 class="module-heading"><i class="fa fa-lg fa-info-circle icon-large icon-info-sign"></i> {{ _('Harvest sources') }}</h2>
     <div class="module-content">
       <p>
         {% trans %}

--- a/ckanext/harvest/templates/source/new_source_form.html
+++ b/ckanext/harvest/templates/source/new_source_form.html
@@ -34,7 +34,7 @@
         <label class="radio">
           <input type="radio" name="source_type" value="{{ harvester['name'] }}" {{ "checked " if checked }} data-module="harvest-type-change">
           {{ harvester['title'] }}
-          <i class="icon-question-sign muted" title="{{ harvester['description'] }}" data-toggle="tooltip"></i>
+          <i class="fa fa-question-circle icon-question-sign muted" title="{{ harvester['description'] }}" data-toggle="tooltip"></i>
         </label>
       {% endfor %}
     </div>

--- a/ckanext/harvest/templates/source/org_source_list.html
+++ b/ckanext/harvest/templates/source/org_source_list.html
@@ -7,7 +7,7 @@
     <h1 class="hide-heading">{{ _('Harvest Sources') }}</h1>
     <div class="primary">
       <a href="{{ h.url_for('harvest_new', group=c.group_dict.id) }}" class="btn pull-right">
-        <i class="icon-plus-sign-alt"></i>
+        <i class="fa fa-plus-square icon-plus-sign-alt"></i>
         {{ _('Add Harvest Source') }}
       </a>
       <h3 class="results page-heading">
@@ -29,7 +29,7 @@
       <form method="GET">
         <span class="control-group search-normal">
           <input type="text" class="search" name="q" value="{{ c.q }}" autocomplete="off" placeholder="{{ _('Search sources...') }}" />
-          <button type="submit"><i class="icon-search"></i> <span>{{ _('Search') }}</span></button>
+          <button type="submit"><i class="fa fa-search icon-search"></i> <span>{{ _('Search') }}</span></button>
         </span>
       </form>
       {% for facet in c.facet_titles %}

--- a/ckanext/harvest/templates/source/search_2.0.html
+++ b/ckanext/harvest/templates/source/search_2.0.html
@@ -39,7 +39,7 @@
                 {%- else -%}
                   {{ value }}
                 {%- endif %}
-                <a href="{{ c.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="icon-remove"></i></a>
+                <a href="{{ c.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times icon-remove"></i></a>
               </span>
             {% endfor %}
           {% endfor %}


### PR DESCRIPTION
CKAN 2.7.x upgrades to FontAwesome 4.x, so the CSS classes need to be
updated in order to work. But because this extension is used in older
CKAN versions as well, we simply add the new classes, while keeping the
old ones for backwards compatibility.

The new names are according to the upgrade guide: https://github.com/FortAwesome/Font-Awesome/wiki/Upgrading-from-3.2.1-to-4