### PR TITLE
Don't delete all solr documents/fail to index harvesters when harvest config blank

### DIFF
--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -705,11 +705,15 @@ def harvest_source_reindex(context, data_dict):
 
     # Remove configuration values
     new_dict = {}
-    if package_dict.get('config'):
-        config = json.loads(package_dict['config'])
-        for key, value in package_dict.iteritems():
-            if key not in config:
-                new_dict[key] = value
+
+    try:
+        config = json.loads(package_dict.get('config', ''))
+    except ValueError:
+        config = {}
+    for key, value in package_dict.iteritems():
+        if key not in config:
+            new_dict[key] = value
+
     package_index = PackageSearchIndex()
     package_index.index_package(new_dict, defer_commit=defer_commit)
 


### PR DESCRIPTION
There is an assumption in the harvester reindex function that the config for a harvester is a valid JSON string however the validator of many harvesters will allow rightfully a empty None value represented as a blank string '' as answer which is false-y in Python. https://github.com/ckan/ckanext-harvest/blob/master/ckanext/harvest/harvesters/ckanharvester.py#L104 https://github.com/ckan/ckanext-spatial/blob/master/ckanext/spatial/harvesters/base.py#L127

This results in no attribute of a completed harvest package being copied to the variable new_dict which results in an empty dict being passed to PackageSearchIndex.index_package(). 
That would probably be not noticed were it not for another assumption; a package with no state should be deleted when next indexed https://github.com/ckan/ckan/blob/master/ckan/lib/search/index.py#L133 
This also would probably not be a problem because you are deleting the package with id None... except there is another bug which deletes all Solr documents any time any package is deleted in recent versions of Solr due to a change of the default implicit operator from AND to OR https://github.com/ckan/ckan/issues/3949

Doing a full search-reindex restores the catalogue from the postgres database but this isn't obvious and would be very annoying in production.

