### PR TITLE
Update 'harvester sources by organization' page to work with latest CKAN

### DIFF
--- a/ckanext/harvest/controllers/organization.py
+++ b/ckanext/harvest/controllers/organization.py
@@ -2,7 +2,7 @@ import logging
 from urllib import urlencode
 
 from ckan import plugins as p
-from ckan.lib.base import c, model, request, render, h, g
+from ckan.lib.base import c, model, request, render, h
 from ckan.lib.base import abort
 import ckan.lib.maintain as maintain
 import ckan.lib.search as search
@@ -33,7 +33,7 @@ class OrganizationController(GroupController):
         q = c.q = request.params.get('q', '')
 
         try:
-            c.group_dict = self._action('group_show')(context, data_dict)
+            c.group_dict = self._action('organization_show')(context, data_dict)
             c.group = context['group']
         except p.toolkit.ObjectNotFound:
             abort(404, p.toolkit._('Group not found'))
@@ -138,13 +138,13 @@ class OrganizationController(GroupController):
                               'res_format': p.toolkit._('Formats'),
                               'license': p.toolkit._('Licence'), }
 
-            for facet in g.facets:
+            for facet in facets:
                 if facet in default_facet_titles:
                     facets[facet] = default_facet_titles[facet]
                 else:
                     facets[facet] = facet
             if dataset_type:
-                fq = fq + 'dataset_type:"{dataset_type}"'.format(dataset_type=dataset_type)
+                fq = fq + 'dataset_type:{dataset_type}'.format(dataset_type=dataset_type)
 
             # Facet titles
             for plugin in p.PluginImplementations(p.IFacets):
@@ -181,9 +181,6 @@ class OrganizationController(GroupController):
             )
 
             c.facets = query['facets']
-            maintain.deprecate_context_item(
-              'facets',
-              'Use `c.search_facets` instead.')
 
             c.search_facets = query['search_facets']
             c.search_facets_limits = {}


### PR DESCRIPTION
I have been trying to use the display at '/organization/harvest/{id}' but noticed the code appears to not be compatible with the latest version of CKAN (as far as I can see, this page isn't actually displayed anywhere on CKAN by default).

This PR fixes those issues and allows the page to display correctly.