### PR TITLE
Add config option for dataset name append type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,6 +166,22 @@ e.g. Fetch all logs with log level INFO:
     }
 
 
+Dataset name generation configuration (optional)
+================================================
+
+If the dataset name is created based on the title, duplicate names may occur.
+To avoid this, a suffix is appended to the name if it already exists.
+
+You can configure the default behaviour in your production.ini:
+
+    ckanext.harvest.default_dataset_name_append = number-sequence
+
+or
+
+    ckanext.harvest.default_dataset_name_append = random-hex
+
+If you don't specify this setting, the default will be number-sequence.
+
 
 Command line interface
 ======================

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -60,7 +60,7 @@ class HarvesterBase(SingletonPlugin):
 
     @classmethod
     def _gen_new_name(cls, title, existing_name=None,
-                      append_type='number-sequence'):
+                      append_type=None):
         '''
         Returns a 'name' for the dataset (URL friendly), based on the title.
 
@@ -79,11 +79,19 @@ class HarvesterBase(SingletonPlugin):
         :type append_type: string
         '''
 
+        # If append_type was given, use it. Otherwise, use the configured default.
+        # If nothing was given and no defaults were set, use 'number-sequence'.
+        if append_type:
+            append_type_param = append_type
+        else:
+            append_type_param = config.get('ckanext.harvest.default_dataset_name_append',
+                                           'number-sequence')
+
         ideal_name = munge_title_to_name(title)
         ideal_name = re.sub('-+', '-', ideal_name)  # collapse multiple dashes
         return cls._ensure_name_is_unique(ideal_name,
                                           existing_name=existing_name,
-                                          append_type=append_type)
+                                          append_type=append_type_param)
 
     @staticmethod
     def _ensure_name_is_unique(ideal_name, existing_name=None,

--- a/ckanext/harvest/tests/harvesters/test_base.py
+++ b/ckanext/harvest/tests/harvesters/test_base.py
@@ -3,6 +3,7 @@ import re
 from nose.tools import assert_equal, assert_in
 from ckanext.harvest import model as harvest_model
 from ckanext.harvest.harvesters.base import HarvesterBase, munge_tag
+from mock import patch
 try:
     from ckan.tests import helpers
     from ckan.tests import factories
@@ -15,8 +16,7 @@ _ensure_name_is_unique = HarvesterBase._ensure_name_is_unique
 
 
 class TestGenNewName(object):
-    @classmethod
-    def setup_class(cls):
+    def setup(self):
         helpers.reset_db()
         harvest_model.setup()
 
@@ -27,6 +27,40 @@ class TestGenNewName(object):
         assert_equal(
             HarvesterBase._gen_new_name('Trees and branches - survey.'),
             'trees-and-branches-survey')
+
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.some_other_config': 'value'})
+    def test_without_config(self):
+        '''Tests if the number suffix is used when no config is set.'''
+        factories.Dataset(name='trees')
+        assert_equal(
+            HarvesterBase._gen_new_name('Trees'),
+            'trees1')
+
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.default_dataset_name_append': 'number-sequence'})
+    def test_number_config(self):
+        factories.Dataset(name='trees')
+        assert_equal(
+            HarvesterBase._gen_new_name('Trees'),
+            'trees1')
+    
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.default_dataset_name_append': 'random-hex'})
+    def test_random_config(self):
+        factories.Dataset(name='trees')
+        new_name =  HarvesterBase._gen_new_name('Trees')
+        
+        assert re.match('trees[\da-f]{5}', new_name)
+    
+    @patch.dict('ckanext.harvest.harvesters.base.config',
+                {'ckanext.harvest.default_dataset_name_append': 'random-hex'})
+    def test_config_override(self):
+        '''Tests if a parameter has precedence over a config value.'''
+        factories.Dataset(name='trees')
+        assert_equal(
+            HarvesterBase._gen_new_name('Trees', append_type='number-sequence'),
+            'trees1')
 
 
 class TestEnsureNameIsUnique(object):


### PR DESCRIPTION
Adds the possibility to set the append_type parameter used in _gen_new_name globally for all harvesters within the CKAN config. So the default type can be changed easily by setting it in the config without the need changing the source code. The default value is still the same and the possibility to overwrite the parameter on function call still exists, too.