### PR TITLE
Send harvest-error-mails to organization-admins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,11 +186,11 @@ If you don't specify this setting, the default will be number-sequence.
 Send error mails when harvesting fails (optional)
 =================================================
 
-If you want to send and email when a Harvest Job fails, you can set the following configuration option in the ini file:
+If you want to send an email when a Harvest Job fails, you can set the following configuration option in the ini file:
 
     ckan.harvest.status_mail.errored = True
 
-That way, all CKAN Users who are declared as Sysadmins will receive the Error emails at their configured email address.
+That way, all CKAN Users who are declared as Sysadmins will receive the Error emails at their configured email address. If the Harvest-Source of the failing Harvest-Job belongs to an organization, the error-mail will also be sent to the organization-members who have the admin-role if their E-Mail is configured.
 
 If you don't specify this setting, the default will be False.
 


### PR DESCRIPTION
This adds the organization-admins to the error-mail-recipients if a harvest-job fails.

Now that the code is way simpler than it originally was, it is not such a big step to send the error-mails to the organization-admins as well.

If the harvest-source belongs to an organization we will query their users who have the admin-role and add them to the recipients, if they have an email configured.