### PR TITLE
Use Redis password from configuration when present.

### DIFF
--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -64,6 +64,7 @@ def get_connection_redis():
     import redis
     return redis.StrictRedis(host=config.get('ckan.harvest.mq.hostname', HOSTNAME),
                           port=int(config.get('ckan.harvest.mq.port', REDIS_PORT)),
+                          password=config.get('ckan.harvest.mq.password', None),
                           db=int(config.get('ckan.harvest.mq.redis_db', REDIS_DB)))
 
 


### PR DESCRIPTION
This PR is in reference to #331.

I have tested it in configurations with and without passwords, but I am not familiar enough with the build environment to add unit tests easily.