### PR TITLE
Switch from urllib2 to requests

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,2 +1,8 @@
 pika==0.9.8
 redis==2.10.1
+idna==2.7
+ndg-httpsclient==0.5.1
+pyasn1==0.4.4
+pyOpenSSL==18.0.0
+urllib3==1.2.3
+enum34==0.4.7


### PR DESCRIPTION
As discussed in #295, `urllib2` should be upgraded to `requests`.  This does that and include backwards compatibility for versions of Python older than 2.7.9 (and also enables support for TLSv1.2, which was lacking previously unless Python 2.7.9 or newer was used).