### PR TITLE
Ensures the AND operator for fq in solr

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -18,7 +18,7 @@ def package_list_for_source(source_id):
     '''
     limit = 20
     page = int(request.params.get('page', 1))
-    fq = 'harvest_source_id:"{0}"'.format(source_id)
+    fq = '+harvest_source_id:"{0}"'.format(source_id)
     search_dict = {
         'fq' : fq,
         'rows': limit,
@@ -66,7 +66,7 @@ def package_count_for_source(source_id):
     Returns the current package count for datasets associated with the given
     source id
     '''
-    fq = 'harvest_source_id:"{0}"'.format(source_id)
+    fq = '+harvest_source_id:"{0}"'.format(source_id)
     search_dict = {'fq': fq}
     context = {'model': model, 'session': model.Session}
     result = logic.get_action('package_search')(context, search_dict)


### PR DESCRIPTION
Without the leading '+', the page of a harvest source shows all datasets available in ckan, not only the ones that belong to the source itself.
package_search() of the ckan core adds '+capacity:public ' in front of the harvest_source_id and without the + it then becomes an OR and all datasets get returned.