### PR TITLE
Replace organization_read with organization.read

### DIFF
--- a/ckanext/harvest/templates/snippets/source_item.html
+++ b/ckanext/harvest/templates/snippets/source_item.html
@@ -42,7 +42,7 @@ Example:
         {{ _('Datasets') }}: {{ source.status.total_datasets }}
       {% endif %}
       {% if not within_organization and source.organization %}
-      &mdash; {{ _('Organization') }}: {{ h.link_to(source.organization.title or source.organization.name, h.url_for('organization_read', id=source.organization.name)) }}</a>
+      &mdash; {{ _('Organization') }}: {{ h.link_to(source.organization.title or source.organization.name, h.url_for('organization.read', id=source.organization.name)) }}</a>
       {% endif %}
     </p>
 

--- a/ckanext/harvest/templates/source/base.html
+++ b/ckanext/harvest/templates/source/base.html
@@ -15,7 +15,7 @@
   {% if source.organization %}
     {% set org = source.organization %}
     <li>{{ h.nav_link(_('Organizations'), named_route='organizations_index') }}</li>
-    <li>{{ h.nav_link(org.title or org.name|truncate(10), named_route='organization_read', id=org.name) }}</li>
+    <li>{{ h.nav_link(org.title or org.name|truncate(10), named_route='organization.read', id=org.name) }}</li>
     <li>{{ h.nav_link(_('Harvest Sources'), named_route='{0}_search'.format(c.dataset_type)) }}</li>
     <li{{ self.breadcrumb_content_root_selected() }}>{{ h.nav_link(c.harvest_source.title|truncate(10), named_route='{0}_read'.format(c.dataset_type), id=c.harvest_source.name) }}</li>
   {% else %}


### PR DESCRIPTION
The patch fixes this warning:

```
INFO  [ckan.lib.helpers] Route name "organization_read" is deprecated and will be removed.
Please update calls to use "organization.read" instead
```