### PR TITLE
A harvester may not have an info method

### DIFF
--- a/ckanext/harvest/logic/validators.py
+++ b/ckanext/harvest/logic/validators.py
@@ -113,7 +113,10 @@ def harvest_source_type_exists(value, context):
     # Get all the registered harvester types
     available_types = []
     for harvester in PluginImplementations(IHarvester):
-        info = harvester.info()
+        try:
+            info = harvester.info()
+        except AttributeError:
+            continue
         if not info or 'name' not in info:
             log.error('Harvester %s does not provide the harvester name in '
                       'the info response' % harvester)


### PR DESCRIPTION
This fixes the error `AttributeError: 'HarvesterBase' object has no attribute 'info'` which prevents new harvest sources from being created in some circumstances.

It also continues enforcing the validation, since a class without a info method still cannot be used as a valid harvest source type.