### PR TITLE
Fix SSL problems for old versions of Python 2.7.x

### DIFF
--- a/ckanext/harvest/templates/source/job/read.html
+++ b/ckanext/harvest/templates/source/job/read.html
@@ -6,7 +6,7 @@
 <div class="module-content">
 
   <p class="pull-right">
-    {{ h.nav_link(_('Back to job list'), named_route='harvest_job_list', source=source.name, class_='btn btn-default', icon='arrow-left')}}
+    {{ h.nav_link(_('Back to job list'), named_route='harvest_job_list', source=harvest_source.name, class_='btn btn-default', icon='arrow-left')}}
   </p>
 
   <h1>{{ _('Job Report') }}</h1>

--- a/ckanext/harvest/tests/test_controller.py
+++ b/ckanext/harvest/tests/test_controller.py
@@ -118,3 +118,24 @@ class TestController(helpers.FunctionalTestBase):
         response = app.get(url, extra_environ=self.extra_environ)
 
         assert_in(job['id'], response.unicode_body)
+
+    def test_job_show_last_page_rendered(self):
+
+        job = harvest_factories.HarvestJob()
+        app = self._get_test_app()
+        url = url_for('harvest_job_show_last', source=job['source_id'])
+
+        response = app.get(url, extra_environ=self.extra_environ)
+
+        assert_in(job['id'], response.unicode_body)
+
+    def test_job_show_page_rendered(self):
+
+        job = harvest_factories.HarvestJob()
+        app = self._get_test_app()
+        url = url_for(
+            'harvest_job_show', source=job['source_id'], id=job['id'])
+
+        response = app.get(url, extra_environ=self.extra_environ)
+
+        assert_in(job['id'], response.unicode_body)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.1.2'
+version = '1.1.3'
 
 setup(
     name='ckanext-harvest',


### PR DESCRIPTION
Hi,

with this patch we solved the connection probelms with urls using SSL when using an old version of Python, such as:

```
/usr/lib/venv/local/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#insecureplatformwarning.
```