### PR TITLE
Fix SSL problems for old versions of Python 2.7.x

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -1,16 +1,12 @@
 import requests
-from requests.exceptions import HTTPError
-from requests.exceptions import InvalidURL
+from requests.exceptions import RequestException
 
-import httplib
 import datetime
-import socket
 from urllib3.contrib import pyopenssl
 
 from ckan import model
 from ckan.logic import ValidationError, NotFound, get_action
 from ckan.lib.helpers import json
-from ckan.lib.munge import munge_name
 from ckan.plugins import toolkit
 
 from ckanext.harvest.model import HarvestObject
@@ -46,17 +42,8 @@ class CKANHarvester(HarvesterBase):
 
         try:
             http_request = requests.get(url, headers=headers)
-        except HTTPError as e:
-            if e.response.status_code == 404:
-                raise ContentNotFoundError('HTTP error: %s' % e.code)
-            else:
-                raise ContentFetchError('HTTP error: %s' % e.code)
-        except InvalidURL as e:
-            raise ContentFetchError('URL error: %s' % e.reason)
-        except httplib.HTTPException as e:
-            raise ContentFetchError('HTTP Exception: %s' % e)
-        except socket.error as e:
-            raise ContentFetchError('HTTP socket error: %s' % e)
+        except RequestException as e:
+            raise ContentFetchError('HTTP error: %s' % e.code)
         except Exception as e:
             raise ContentFetchError('HTTP general exception: %s' % e)
         return http_request.text

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -3,6 +3,7 @@ from requests.exceptions import RequestException
 
 import datetime
 from urllib3.contrib import pyopenssl
+import urllib
 
 from ckan import model
 from ckan.logic import ValidationError, NotFound, get_action

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,2 +1,9 @@
 pika==0.9.8
 redis==2.10.1
+requests==2.20.0
+idna==2.7
+ndg-httpsclient==0.5.1
+pyasn1==0.4.4
+pyOpenSSL==18.0.0
+urllib3==1.23
+enum34==1.1.6

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,9 +1,4 @@
 pika==0.9.8
 redis==2.10.1
 requests==2.20.0
-idna==2.7
-ndg-httpsclient==0.5.1
-pyasn1==0.4.4
 pyOpenSSL==18.0.0
-urllib3==1.23
-enum34==1.1.6


### PR DESCRIPTION
Hi,

with this patch we solved the connection probelms with urls using SSL when using an old version of Python, such as:

```
/usr/lib/venv/local/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#insecureplatformwarning.
```