### PR TITLE
Add an 'owner_org' to the v3 package migration

### DIFF
--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -574,6 +574,7 @@ def migrate_v3_create_datasets(source_ids=None):
             'source_type': source.type,
             'config': source.config,
             'frequency': source.frequency,
+            'owner_org': source.publisher_id,
             }
         context['message'] = 'Created package for harvest source {0}'.format(source.id)
         try:


### PR DESCRIPTION
The auto-migration fails because the new package does not have an owner organisation ID assigned, so fails validation