### PR TITLE
Fix harvest request exceptions

### DIFF
--- a/ckanext/harvest/templates/source/job/read.html
+++ b/ckanext/harvest/templates/source/job/read.html
@@ -6,7 +6,7 @@
 <div class="module-content">
 
   <p class="pull-right">
-    {{ h.nav_link(_('Back to job list'), named_route='harvest_job_list', source=source.name, class_='btn btn-default', icon='arrow-left')}}
+    {{ h.nav_link(_('Back to job list'), named_route='harvest_job_list', source=harvest_source.name, class_='btn btn-default', icon='arrow-left')}}
   </p>
 
   <h1>{{ _('Job Report') }}</h1>

--- a/ckanext/harvest/tests/test_controller.py
+++ b/ckanext/harvest/tests/test_controller.py
@@ -118,3 +118,24 @@ class TestController(helpers.FunctionalTestBase):
         response = app.get(url, extra_environ=self.extra_environ)
 
         assert_in(job['id'], response.unicode_body)
+
+    def test_job_show_last_page_rendered(self):
+
+        job = harvest_factories.HarvestJob()
+        app = self._get_test_app()
+        url = url_for('harvest_job_show_last', source=job['source_id'])
+
+        response = app.get(url, extra_environ=self.extra_environ)
+
+        assert_in(job['id'], response.unicode_body)
+
+    def test_job_show_page_rendered(self):
+
+        job = harvest_factories.HarvestJob()
+        app = self._get_test_app()
+        url = url_for(
+            'harvest_job_show', source=job['source_id'], id=job['id'])
+
+        response = app.get(url, extra_environ=self.extra_environ)
+
+        assert_in(job['id'], response.unicode_body)


### PR DESCRIPTION
We are currently getting a error AttributeError: `SSLError` object has no attribute `code`. 
This changes the harvest exception handling so we can correctly log the error.