### PR TITLE
Fix harvest request exceptions

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -1,5 +1,5 @@
 import requests
-from requests.exceptions import RequestException
+from requests.exceptions import HTTPError, RequestException
 
 import datetime
 from urllib3.contrib import pyopenssl

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -43,8 +43,10 @@ class CKANHarvester(HarvesterBase):
 
         try:
             http_request = requests.get(url, headers=headers)
+        except HTTPError as e:
+            raise ContentFetchError('HTTP error: %s %s' % (e.response.status_code, e.request.url))
         except RequestException as e:
-            raise ContentFetchError('HTTP error: %s' % e.code)
+            raise ContentFetchError('Request error: %s' % e)
         except Exception as e:
             raise ContentFetchError('HTTP general exception: %s' % e)
         return http_request.text

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -4,7 +4,6 @@ from nose.tools import assert_equal, assert_raises, assert_in
 import json
 from mock import patch, MagicMock, Mock
 from requests.exceptions import HTTPError, RequestException
-import unittest
 
 try:
     from ckan.tests.helpers import reset_db, call_action
@@ -340,7 +339,6 @@ class TestCkanHarvester(object):
                 config=json.dumps(config))
         assert_in('default_extras must be a dictionary',
                   str(harvest_context.exception))
-
 
     @patch('ckanext.harvest.harvesters.ckanharvester.pyopenssl.inject_into_urllib3')
     @patch('ckanext.harvest.harvesters.ckanharvester.CKANHarvester.config')


### PR DESCRIPTION
We are currently getting a error AttributeError: SSLError object has no attribute code.
This changes the harvest exception handling so we can correctly log the error.

Also tests were added to show that the exceptions are being handled correctly.