### PR TITLE
Use ckantoolkit to clean up imports

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased_
 Changed
 -------
 - Apply flake8 to be PEP-8 compliant #354
+- Use ckantoolkit to clean up imports #358
 
 Fixed
 -----

--- a/ckanext/harvest/tests/factories.py
+++ b/ckanext/harvest/tests/factories.py
@@ -1,9 +1,6 @@
 import factory
 import ckanext.harvest.model as harvest_model
-try:
-    from ckan.new_tests.factories import _get_action_user_name
-except ImportError:
-    from ckan.tests.factories import _get_action_user_name
+from ckantoolkit.tests.factories import _get_action_user_name
 from ckan.plugins import toolkit
 
 

--- a/ckanext/harvest/tests/harvesters/test_base.py
+++ b/ckanext/harvest/tests/harvesters/test_base.py
@@ -4,13 +4,7 @@ from nose.tools import assert_equal, assert_in
 from ckanext.harvest import model as harvest_model
 from ckanext.harvest.harvesters.base import HarvesterBase, munge_tag
 from mock import patch
-try:
-    from ckan.tests import helpers
-    from ckan.tests import factories
-except ImportError:
-    from ckan.new_tests import helpers
-    from ckan.new_tests import factories
-
+from ckantoolkit.tests import helpers, factories
 
 _ensure_name_is_unique = HarvesterBase._ensure_name_is_unique
 

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -5,12 +5,8 @@ import json
 from mock import patch, MagicMock, Mock
 from requests.exceptions import HTTPError, RequestException
 
-try:
-    from ckan.tests.helpers import reset_db, call_action
-    from ckan.tests.factories import Organization, Group
-except ImportError:
-    from ckan.new_tests.helpers import reset_db, call_action
-    from ckan.new_tests.factories import Organization, Group
+from ckantoolkit.tests.helpers import reset_db, call_action
+from ckantoolkit.tests.factories import Organization, Group
 from ckan import model
 from ckan.plugins import toolkit
 

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -2,30 +2,12 @@ import json
 import factories
 import unittest
 from mock import patch
-from nose.tools import assert_equal, assert_raises
+from nose.tools import assert_equal, assert_raises, assert_in
 from nose.plugins.skip import SkipTest
 
-try:
-    from ckan.tests import factories as ckan_factories
-    from ckan.tests.helpers import (_get_test_app, reset_db,
-                                    FunctionalTestBase)
-except ImportError:
-    from ckan.new_tests import factories as ckan_factories
-    from ckan.new_tests.helpers import (_get_test_app, reset_db,
-                                        FunctionalTestBase)
-try:
-    from ckan.tests.helpers import assert_in
-except ImportError:
-    try:
-        from ckan.new_tests.helpers import assert_in
-    except ImportError:
-        # for ckan 2.2
-        try:
-            from nose.tools import assert_in
-        except ImportError:
-            # Python 2.6 doesn't have it
-            def assert_in(a, b, msg=None):
-                assert a in b, msg or '%r was not in %r' % (a, b)
+
+from ckantoolkit.tests import factories as ckan_factories
+from ckantoolkit.tests.helpers import _get_test_app, reset_db, FunctionalTestBase
 
 from ckan import plugins as p
 from ckan.plugins import toolkit

--- a/ckanext/harvest/tests/test_controller.py
+++ b/ckanext/harvest/tests/test_controller.py
@@ -1,23 +1,8 @@
 from ckan.lib.helpers import url_for
 
-try:
-    from ckan.tests import helpers, factories
-except ImportError:
-    from ckan.new_tests import helpers, factories
-
+from ckantoolkit.tests import helpers, factories
 from ckanext.harvest.tests import factories as harvest_factories
-
-try:
-    from ckan.tests.helpers import assert_in
-except ImportError:
-    # for ckan 2.2
-    try:
-        from nose.tools import assert_in
-    except ImportError:
-        # Python 2.6 doesn't have it
-        def assert_in(a, b, msg=None):
-            assert a in b, msg or '%r was not in %r' % (a, b)
-
+from nose.tools import assert_in
 import ckanext.harvest.model as harvest_model
 
 

--- a/ckanext/harvest/tests/test_queue.py
+++ b/ckanext/harvest/tests/test_queue.py
@@ -1,7 +1,4 @@
-try:
-    from ckan.tests.helpers import reset_db
-except ImportError:
-    from ckan.new_tests.helpers import reset_db
+from ckantoolkit.tests.helpers import reset_db
 import ckanext.harvest.model as harvest_model
 from ckanext.harvest.model import HarvestObject, HarvestObjectExtra
 from ckanext.harvest.interfaces import IHarvester

--- a/ckanext/harvest/tests/test_queue2.py
+++ b/ckanext/harvest/tests/test_queue2.py
@@ -4,11 +4,8 @@
 import json
 
 from nose.tools import assert_equal
+from ckantoolkit.tests.helpers import reset_db
 
-try:
-    from ckan.tests.helpers import reset_db
-except ImportError:
-    from ckan.new_tests.helpers import reset_db
 from ckan import model
 from ckan import plugins as p
 from ckan.plugins import toolkit

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -2,3 +2,4 @@ pika==0.9.8
 redis==2.10.1
 requests==2.20.0
 pyOpenSSL==18.0.0
+ckantoolkit==0.0.3


### PR DESCRIPTION
This PR makes use of the `ckantoolkit` to cleanup the imports that were previously needed for different versions of CKAN.