### PR TITLE
Remove old database migrations that targeted ancient versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 - Use ckantoolkit to clean up imports #358
 - Add hook to extend the package dict in CKAN harvester
 - Use CKAN core ckan.redis.url setting if present
+- Remove database migration code targeting ancient versions
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,10 @@ Changed
 - Use ckantoolkit to clean up imports #358
 - Add hook to extend the package dict in CKAN harvester
 - Use CKAN core ckan.redis.url setting if present
-- Remove database migration code targeting ancient versions
+- Remove database migration code targeting ancient versions #376
+    (In the unlikely event that you need to upgrade from one
+     of the previous DB versions just apply the changes removed
+     on the linked PR manually)
 
 Fixed
 -----


### PR DESCRIPTION
For the version we are in it is safe to assume that is these migrations are no longer needed. They can introduce hard to track errors as part of the startup work they did.