### PR TITLE
get message from harvest_object_error-dict

### DIFF
--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -610,8 +610,10 @@ def send_error_mail(context, source_id, status):
     obj_error = ''
     job_error = ''
 
-    for harvest_object_error in islice(report.get('object_errors'), 0, 20):
-        obj_error += harvest_object_error['message'] + '\n'
+    for harvest_object_error_key in islice(report.get('object_errors'), 0, 20):
+        harvest_object_error = report.get('object_errors')[harvest_object_error_key]['errors']
+        for error in harvest_object_error:
+            obj_error += error['message']
 
     for harvest_gather_error in islice(report.get('gather_errors'), 0, 20):
         job_error += harvest_gather_error['message'] + '\n'


### PR DESCRIPTION
When activating this feature for a new client, I realised that the `harvest_object_error` structure is very different from what `harvest_gather_error` looks like.

An example of a `harvest_object_error`:

```
'object_errors': {u'02aa088c-5272-4b71-bdb1-e2d887e020f2': {'errors': [{'line': None,
                                                                         'message': u'Ftplib error,
                                                                         'type': u'Fetch'}],
                                                             'guid': u'Custom Harvester'},
```

If I am getting something wrong, I'd be happy for advice.

Irony is, that the original code is mine and I wonder, why this ever worked 😅 