### PR TITLE
Check for auth before rendering admin link.

### DIFF
--- a/ckanext/harvest/templates/source/read_base.html
+++ b/ckanext/harvest/templates/source/read_base.html
@@ -1,7 +1,9 @@
 {% extends "source/base.html" %}
 
 {% block admin_link %}
-  {{ h.nav_link(_('Admin'), named_route='{0}_admin'.format(c.dataset_type), id=harvest_source.name, class_='btn btn-primary', icon='wrench')}}
+  {% if h.check_access('harvest_source_update', {'id':harvest_source.id }) %}
+    {{ h.nav_link(_('Admin'), named_route='{0}_admin'.format(c.dataset_type), id=harvest_source.name, class_='btn btn-primary', icon='wrench')}}
+  {% endif %}
 {% endblock %}
 
 {# CKAN 2.0 #}


### PR DESCRIPTION
Note that the incorectly rendered admin link does _not_ grant authorization to update the harvest source. The auth appears to be correct. The problems appears to be that the admin link is rendered when it should not be. Following the link results in 401 when rendered for a user without the correct permissions.