### PR TITLE
Fix show object

### DIFF
--- a/ckanext/harvest/controllers/view.py
+++ b/ckanext/harvest/controllers/view.py
@@ -23,8 +23,8 @@ class ViewController(BaseController):
         return utils.clear_view(id)
 
     def show_object(self, id, ref_type='object'):
-        obj = utils.object_show_view(id, ref_type, response)
-        return obj.content
+        _, content = utils.object_show_view(id, ref_type, response)
+        return content
 
     def show_job(self, id, source_dict=False, is_last=False):
         return utils.job_show_view(id, source_dict, is_last)

--- a/ckanext/harvest/tests/nose/test_controller.py
+++ b/ckanext/harvest/tests/nose/test_controller.py
@@ -4,6 +4,8 @@ from ckantoolkit.tests import helpers, factories
 from ckanext.harvest.tests.nose import factories as harvest_factories
 from nose.tools import assert_in
 import ckanext.harvest.model as harvest_model
+from ckan.plugins import toolkit
+from ckan import model
 
 
 class TestController(helpers.FunctionalTestBase):
@@ -124,3 +126,29 @@ class TestController(helpers.FunctionalTestBase):
         response = app.get(url, extra_environ=self.extra_environ)
 
         assert_in(job['id'], response.unicode_body)
+
+    def test_job_show_object(self):
+        source_obj = harvest_factories.HarvestSourceObj()
+        job = harvest_factories.HarvestJob(source=source_obj)
+
+        context = {
+            'model': model,
+            'session': model.Session,
+            'ignore_auth': True,
+        }
+        data_dict = {
+            'guid': 'guid',
+            'content': 'test content',
+            'job_id': job['id'],
+            'source_id': source_obj.id,
+            'extras': {'a key': 'a value'},
+        }
+        harvest_object = toolkit.get_action('harvest_object_create')(
+            context, data_dict)
+
+        app = self._get_test_app()
+        url = url_for('harvest_object_show', id=harvest_object['id'])
+
+        response = app.get(url)
+
+        assert_in(data_dict['content'], response.unicode_body)

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,5 +1,6 @@
+ckantoolkit==0.0.3
 pika>=1.1.0
+pyOpenSSL==18.0.0
 redis>=3.3.0
 requests==2.20.0
-pyOpenSSL==18.0.0
-ckantoolkit==0.0.3
+six==1.12.0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -3,4 +3,4 @@ pika>=1.1.0
 pyOpenSSL==18.0.0
 redis>=3.3.0
 requests==2.20.0
-six==1.12.0
+six>=1.12.0


### PR DESCRIPTION
## What

It wasn't possible to view the content of harvest source content as the `object_show_view` function wasn't expecting a tuple. 

Additionally we need to ensure that we are using at least six version 1.12.0 in order for `ensure_str` to be available in `six` library
