### PR TITLE
fix clearsource_history command to avoid disassociation

### DIFF
--- a/ckanext/harvest/cli.py
+++ b/ckanext/harvest/cli.py
@@ -108,7 +108,11 @@ def clear(ctx, id):
 
 @source.command()
 @click.argument(u"id", metavar=u"SOURCE_ID_OR_NAME", required=False)
-@click.argument(u"keep_actual", default=False, required=False)
+@click.option(
+    "-k",
+    "--keep-actual",
+    default=False
+)
 @click.pass_context
 def clear_history(ctx, id, keep_actual):
     """If no source id is given the history for all harvest sources

--- a/ckanext/harvest/cli.py
+++ b/ckanext/harvest/cli.py
@@ -108,8 +108,9 @@ def clear(ctx, id):
 
 @source.command()
 @click.argument(u"id", metavar=u"SOURCE_ID_OR_NAME", required=False)
+@click.argument(u"keep_actual", default=False, required=False)
 @click.pass_context
-def clear_history(ctx, id):
+def clear_history(ctx, id, keep_actual):
     """If no source id is given the history for all harvest sources
     (maximum is 1000) will be cleared.
 
@@ -122,7 +123,7 @@ def clear_history(ctx, id):
     flask_app = ctx.meta["flask_app"]
 
     with flask_app.test_request_context():
-        result = utils.clear_harvest_source_history(id)
+        result = utils.clear_harvest_source_history(id, bool(keep_actual))
     click.secho(result, fg="green")
 
 

--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -162,6 +162,14 @@ class Harvester(CkanCommand):
  the 16 harvest object segments to import. e.g. 15af will run segments 1,5,a,f""",
         )
 
+        self.parser.add_option(
+            "-k",
+            "--keep-actual",
+            dest="keep_actual",
+            default=False,
+            help="Do not delete relevant harvest objects",
+        )
+
     def command(self):
         self._load_config()
 
@@ -286,11 +294,13 @@ class Harvester(CkanCommand):
         print(result)
 
     def clear_harvest_source_history(self):
+        keep_actual = bool(self.options.keep_actual)
         source_id = None
+
         if len(self.args) >= 2:
             source_id = unicode(self.args[1])
 
-        print(utils.clear_harvest_source_history(source_id))
+        print(utils.clear_harvest_source_history(source_id, keep_actual))
 
     def show_harvest_source(self):
 

--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -1,4 +1,5 @@
 
+import ipdb
 from ckan import logic
 from ckan import model
 import ckan.lib.helpers as h
@@ -55,8 +56,10 @@ def package_list_for_source(source_id):
             context['ignore_capacity_check'] = True
 
     query = logic.get_action('package_search')(context, search_dict)
-
-    base_url = h.url_for('{0}_read'.format(DATASET_TYPE_NAME), id=source_id)
+    base_url = h.url_for(
+        '{0}_read'.format(DATASET_TYPE_NAME),
+        id=harvest_source.get('name')
+    )
 
     def pager_url(q=None, page=None):
         url = base_url

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -297,20 +297,22 @@ def harvest_source_job_history_clear(context, data_dict):
      IN (SELECT id FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}');
     DELETE FROM harvest_object_extra WHERE harvest_object_id
      IN (SELECT id FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}');
-    DELETE FROM harvest_gather_error WHERE harvest_job_id
-     IN (SELECT id FROM harvest_job WHERE source_id = '{harvest_source_id}');
     '''
 
     if keep_actual:
         sql += '''
         DELETE FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}'
-        AND current != true AND
-        (report_status IS NULL OR report_status NOT IN ('added', 'updated', 'not modified'));
-        DELETE FROM harvest_job AS job WHERE NOT EXISTS (
-            SELECT id FROM harvest_object WHERE harvest_job_id = job.id);
+         AND current != true;
+        DELETE FROM harvest_gather_error AS err WHERE NOT EXISTS
+         (SELECT id FROM harvest_object WHERE harvest_job_id = err.harvest_job_id
+          AND harvest_source_id = '{harvest_source_id}');
+        DELETE FROM harvest_job AS job WHERE source_id = '{harvest_source_id}'
+         AND NOT EXISTS (SELECT id FROM harvest_object WHERE harvest_job_id = job.id);
         '''
     else:
         sql += '''
+        DELETE FROM harvest_gather_error WHERE harvest_job_id
+         IN (SELECT id FROM harvest_job WHERE source_id = '{harvest_source_id}');
         DELETE FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}';
         DELETE FROM harvest_job WHERE source_id = '{harvest_source_id}';
         '''

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -307,6 +307,7 @@ def harvest_source_job_history_clear(context, data_dict):
          (SELECT id FROM harvest_object WHERE harvest_job_id = err.harvest_job_id
           AND harvest_source_id = '{harvest_source_id}');
         DELETE FROM harvest_job AS job WHERE source_id = '{harvest_source_id}'
+         AND job.status != 'Running'
          AND NOT EXISTS (SELECT id FROM harvest_object WHERE harvest_job_id = job.id);
         '''
     else:

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -292,29 +292,30 @@ def harvest_source_job_history_clear(context, data_dict):
 
     model = context['model']
 
-    sql = '''begin;
-    delete from harvest_object_error where harvest_object_id
-     in (select id from harvest_object where harvest_source_id = '{harvest_source_id}');
-    delete from harvest_object_extra where harvest_object_id
-     in (select id from harvest_object where harvest_source_id = '{harvest_source_id}');
-    delete from harvest_gather_error where harvest_job_id
-     in (select id from harvest_job where source_id = '{harvest_source_id}');
+    sql = '''BEGIN;
+    DELETE FROM harvest_object_error WHERE harvest_object_id
+     IN (SELECT id FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}');
+    DELETE FROM harvest_object_extra WHERE harvest_object_id
+     IN (SELECT id FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}');
+    DELETE FROM harvest_gather_error WHERE harvest_job_id
+     IN (SELECT id FROM harvest_job WHERE source_id = '{harvest_source_id}');
     '''
 
     if keep_actual:
         sql += '''
-        delete from harvest_object where harvest_source_id = '{harvest_source_id}'
-        and current != true and (report_status is null or report_status != 'added');
+        DELETE FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}'
+        AND current != true AND
+        (report_status IS NULL OR report_status NOT IN ('added', 'updated', 'not modified'));
         DELETE FROM harvest_job AS job WHERE NOT EXISTS (
             SELECT id FROM harvest_object WHERE harvest_job_id = job.id);
         '''
     else:
         sql += '''
-        delete from harvest_object where harvest_source_id = '{harvest_source_id}';
-        delete from harvest_job where source_id = '{harvest_source_id}';
+        DELETE FROM harvest_object WHERE harvest_source_id = '{harvest_source_id}';
+        DELETE FROM harvest_job WHERE source_id = '{harvest_source_id}';
         '''
     sql += '''
-    commit;
+    COMMIT;
     '''
 
     model.Session.execute(sql.format(harvest_source_id=harvest_source_id))

--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -141,7 +141,7 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
             # package_show
             if data_dict.get('extras'):
                 data_dict['extras'][:] = [e for e in data_dict.get('extras', [])
-                                          if not e['key']
+                                          if not e.get('key')
                                           in ('harvest_object_id', 'harvest_source_id', 'harvest_source_title',)]
 
             # We only want to add these extras at index time so they are part

--- a/ckanext/harvest/tests/nose/test_action.py
+++ b/ckanext/harvest/tests/nose/test_action.py
@@ -425,6 +425,79 @@ class TestActions(ActionBase):
         dataset_from_db_2 = model.Package.get(dataset_2['id'])
         assert dataset_from_db_2, 'is None'
         assert_equal(dataset_from_db_2.id, dataset_2['id'])
+    
+    def test_harvest_sources_job_history_clear_keep_actual(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source_1 = factories.HarvestSourceObj(**data_dict)
+        data_dict['name'] = 'another-source'
+        data_dict['url'] = 'http://another-url'
+        source_2 = factories.HarvestSourceObj(**data_dict)
+
+        job_1 = factories.HarvestJobObj(source=source_1)
+        dataset_1 = ckan_factories.Dataset()
+        object_1_ = factories.HarvestObjectObj(job=job_1, source=source_1,
+                                               package_id=dataset_1['id'])
+
+        job_2 = factories.HarvestJobObj(source=source_2)
+        # creating harvest_object with empty package_id
+        object_2_ = factories.HarvestObjectObj(job=job_2, source=source_2,
+                                               package_id=None)
+
+        setattr(object_1_, 'report_status', 'added')
+        setattr(object_1_, 'current', True)
+        model.Session.commit()
+
+        # execute
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+        result = toolkit.get_action('harvest_sources_job_history_clear')(
+            context, {'keep_actual': True})
+
+        # verify
+        assert_equal(
+            sorted(result),
+            sorted([{'id': source_1.id}, {'id': source_2.id}]))
+
+        # dataset, related source, object and job still persist!
+        assert harvest_model.HarvestSource.get(source_1.id)
+        assert harvest_model.HarvestJob.get(job_1.id)
+        assert harvest_model.HarvestObject.get(object_1_.id)
+        dataset_from_db_1 = model.Package.get(dataset_1['id'])
+        assert dataset_from_db_1, 'is None'
+        assert_equal(dataset_from_db_1.id, dataset_1['id'])
+
+        # second source persist, but job and object was deleted
+        assert harvest_model.HarvestSource.get(source_2.id)
+        assert not harvest_model.HarvestJob.get(job_2.id)
+        assert not harvest_model.HarvestObject.get(object_2_.id)
+
+    def test_harvest_source_job_history_clear_keep_actual(self):
+        # prepare
+        source = factories.HarvestSourceObj(**SOURCE_DICT.copy())
+        job = factories.HarvestJobObj(source=source)
+        dataset = ckan_factories.Dataset()
+        object_ = factories.HarvestObjectObj(job=job, source=source,
+                                             package_id=dataset['id'])
+
+        setattr(object_, 'report_status', 'added')
+        setattr(object_, 'current', True)
+        model.Session.commit()
+
+        # execute
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+        result = toolkit.get_action('harvest_source_job_history_clear')(
+            context, {'id': source.id, 'keep_actual': True})
+
+        # verify
+        assert_equal(result, {'id': source.id})
+        assert harvest_model.HarvestSource.get(source.id)
+        assert harvest_model.HarvestJob.get(job.id)
+        assert harvest_model.HarvestObject.get(object_.id)
+        dataset_from_db = model.Package.get(dataset['id'])
+        assert dataset_from_db, 'is None'
+        assert_equal(dataset_from_db.id, dataset['id'])
 
     def test_harvest_source_create_twice_with_unique_url(self):
         data_dict = SOURCE_DICT.copy()

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -362,14 +362,22 @@ class TestActions():
 
     def test_harvest_source_job_history_clear_keep_actual(self):
         # prepare
-        source = factories.HarvestSourceObj(**SOURCE_DICT.copy())
+        data_dict = SOURCE_DICT.copy()
+        data_dict['name'] = 'another-source12'
+        data_dict['url'] = 'http://another-url12'
+        source = factories.HarvestSourceObj(**data_dict)
+
         job = factories.HarvestJobObj(source=source)
         dataset = ckan_factories.Dataset()
         object_ = factories.HarvestObjectObj(job=job, source=source,
                                              package_id=dataset['id'])
 
+        setattr(object_, 'report_status', 'added')
+        setattr(object_, 'current', True)
+        model.Session.commit()
+
         # execute
-        context = {'session': model.Session,
+        context = {'model': model, 'session': model.Session,
                    'ignore_auth': True, 'user': ''}
         result = get_action('harvest_source_job_history_clear')(
             context, {'id': source.id, 'keep_actual': True})

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -292,7 +292,7 @@ class TestActions():
                                                package_id=dataset_2['id'])
 
         # execute
-        context = {'session': model.Session,
+        context = {'model': model, 'session': model.Session,
                    'ignore_auth': True, 'user': ''}
         result = get_action('harvest_sources_job_history_clear')(
             context, {})
@@ -338,7 +338,7 @@ class TestActions():
         model.Session.commit()
 
         # execute
-        context = {'session': model.Session,
+        context = {'model': model, 'session': model.Session,
                    'ignore_auth': True, 'user': ''}
         result = get_action('harvest_sources_job_history_clear')(
             context, {})
@@ -353,7 +353,7 @@ class TestActions():
         assert harvest_model.HarvestObject.get(object_1_.id)
         dataset_from_db_1 = model.Package.get(dataset_1['id'])
         assert dataset_from_db_1, 'is None'
-        assert_equal(dataset_from_db_1.id, dataset_1['id'])
+        assert dataset_from_db_1.id == dataset_1['id']
 
         # second source persist, but job and object was deleted
         assert harvest_model.HarvestSource.get(source_2.id)

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -341,7 +341,7 @@ class TestActions():
         context = {'model': model, 'session': model.Session,
                    'ignore_auth': True, 'user': ''}
         result = get_action('harvest_sources_job_history_clear')(
-            context, {})
+            context, {'keep_actual': True})
 
         # verify
         assert sorted(result, key=lambda item: item['id']) == sorted(
@@ -372,7 +372,7 @@ class TestActions():
         context = {'session': model.Session,
                    'ignore_auth': True, 'user': ''}
         result = get_action('harvest_source_job_history_clear')(
-            context, {'id': source.id})
+            context, {'id': source.id, 'keep_actual': True})
 
         # verify
         assert result == {'id': source.id}

--- a/ckanext/harvest/utils.py
+++ b/ckanext/harvest/utils.py
@@ -206,8 +206,7 @@ def clear_harvest_source(source_id_or_name):
     tk.get_action("harvest_source_clear")(context, {"id": source["id"]})
 
 
-def clear_harvest_source_history(source_id):
-
+def clear_harvest_source_history(source_id, keep_actual):
     context = {
         "model": model,
         "user": _admin_user()["name"],
@@ -215,7 +214,8 @@ def clear_harvest_source_history(source_id):
     }
     if source_id is not None:
         tk.get_action("harvest_source_job_history_clear")(context, {
-            "id": source_id
+            "id": source_id,
+            "keep_actual": keep_actual
         })
         return "Cleared job history of harvest source: {0}".format(source_id)
     else:
@@ -223,7 +223,9 @@ def clear_harvest_source_history(source_id):
         # objects in the database.
         purge_queues()
         cleared_sources_dicts = tk.get_action(
-            "harvest_sources_job_history_clear")(context, {})
+            "harvest_sources_job_history_clear")(context, {
+                "keep_actual": keep_actual
+            })
         return "Cleared job history for all harvest sources: {0} source(s)".format(
             len(cleared_sources_dicts))
 


### PR DESCRIPTION
We encountered a huge problem with disassociation on a production serer a few days ago. This PR tries to fix it by adding an option to an existing clearsource_history command. The main idea is when we have the harvest_object associated with an existing package, we don't wanna loose it and so we don't wanna delete the harvest_job. I'm not entirely sure about this PR, so I'll appreciate any observation about this approach.