### PR TITLE
Abort failed jobs cli command

### DIFF
--- a/ckanext/harvest/cli.py
+++ b/ckanext/harvest/cli.py
@@ -206,18 +206,18 @@ def job_abort(ctx, id):
     "-e",
     "--exclude",
     default=False,
-    help="""If source_id provided as excluded, all sources failed jobs, except for that 
+    help="""If source_id provided as excluded, all sources failed jobs, except for that
     will be aborted. You can use comma as a separator to provide multiple source_id's""",
 )
 @click.pass_context
 def abort_failed_jobs(ctx, life_span, include, exclude):
     """Abort all jobs which are in a "limbo state" where the job has
-    run with errors but the harvester run command will not mark it 
+    run with errors but the harvester run command will not mark it
     as finished, and therefore you cannot run another job.
     """
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
-        result = abort_failed_jobs(job_life_span, include, exclude)
+        result = utils.abort_failed_jobs(life_span, include, exclude)
     click.echo(result)
 
 

--- a/ckanext/harvest/cli.py
+++ b/ckanext/harvest/cli.py
@@ -194,6 +194,34 @@ def job_abort(ctx, id):
 
 
 @harvester.command()
+@click.argument("life_span", default=False, required=False)
+@click.option(
+    "-i",
+    "--include",
+    default=False,
+    help="""If source_id provided as included, then only it's failed jobs will be aborted.
+    You can use comma as a separator to provide multiple source_id's""",
+)
+@click.option(
+    "-e",
+    "--exclude",
+    default=False,
+    help="""If source_id provided as excluded, all sources failed jobs, except for that 
+    will be aborted. You can use comma as a separator to provide multiple source_id's""",
+)
+@click.pass_context
+def abort_failed_jobs(ctx, life_span, include, exclude):
+    """Abort all jobs which are in a "limbo state" where the job has
+    run with errors but the harvester run command will not mark it 
+    as finished, and therefore you cannot run another job.
+    """
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        result = abort_failed_jobs(job_life_span, include, exclude)
+    click.echo(result)
+
+
+@harvester.command()
 def purge_queues():
     """Removes all jobs from fetch and gather queue.
     """

--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -77,7 +77,7 @@ class Harvester(CkanCommand):
 
       harvester abort_failed_jobs {job_life_span} [--include={source_id}] [--exclude={source_id}]
         - abort all jobs which are in a "limbo state" where the job has
-          run with errors but the harvester run command will not mark it 
+          run with errors but the harvester run command will not mark it
           as finished, and therefore you cannot run another job.
 
           job_life_span determines from what moment
@@ -184,7 +184,7 @@ class Harvester(CkanCommand):
             "--exclude",
             dest="exclude_sources",
             default=False,
-            help="""If source_id provided as excluded, all sources failed jobs, except for that 
+            help="""If source_id provided as excluded, all sources failed jobs, except for that
             will be aborted. You can use comma as a separator to provide multiple source_id's""",
         )
 

--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -75,6 +75,14 @@ class Harvester(CkanCommand):
       harvester purge_queues
         - removes all jobs from fetch and gather queue
 
+      harvester abort_failed_jobs {job_life_span} [--include={source_id}] [--exclude={source_id}]
+        - abort all jobs which are in a "limbo state" where the job has
+          run with errors but the harvester run command will not mark it 
+          as finished, and therefore you cannot run another job.
+
+          job_life_span determines from what moment
+          the job must be considered as failed
+
       harvester clean_harvest_log
         - Clean-up mechanism for the harvest log table.
           You can configure the time frame through the configuration
@@ -162,6 +170,24 @@ class Harvester(CkanCommand):
  the 16 harvest object segments to import. e.g. 15af will run segments 1,5,a,f""",
         )
 
+        self.parser.add_option(
+            "-i",
+            "--include",
+            dest="include_sources",
+            default=False,
+            help="""If source_id provided as included, then only it's failed jobs will be aborted.
+            You can use comma as a separator to provide multiple source_id's""",
+        )
+
+        self.parser.add_option(
+            "-e",
+            "--exclude",
+            dest="exclude_sources",
+            default=False,
+            help="""If source_id provided as excluded, all sources failed jobs, except for that 
+            will be aborted. You can use comma as a separator to provide multiple source_id's""",
+        )
+
     def command(self):
         self._load_config()
 
@@ -209,6 +235,8 @@ class Harvester(CkanCommand):
             utils.fetch_consumer()
         elif cmd == "purge_queues":
             self.purge_queues()
+        elif cmd == "abort_failed_jobs":
+            self.abort_failed_jobs()
         elif cmd == "initdb":
             self.initdb()
         elif cmd == "import":
@@ -392,3 +420,14 @@ class Harvester(CkanCommand):
 
     def clean_harvest_log(self):
         utils.clean_harvest_log()
+
+    def abort_failed_jobs(self):
+        job_life_span = False
+        if len(self.args) >= 2:
+            job_life_span = unicode(self.args[1])
+
+        utils.abort_failed_jobs(
+            job_life_span,
+            include=self.options.include_sources,
+            exclude=self.options.exclude_sources
+        )

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -315,6 +315,185 @@ class TestActions():
         assert dataset_from_db_2, 'is None'
         assert dataset_from_db_2.id == dataset_2['id']
 
+    def test_harvest_abort_failed_jobs_without_failed_jobs(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source = factories.HarvestSourceObj(**data_dict)
+        job = factories.HarvestJobObj(source=source)
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+        result = get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3})
+
+        job = harvest_model.HarvestJob.get(job.id)
+
+        assert job.status == 'New'
+        assert job.source_id == source.id
+        assert result == 'There is no jobs to abort'
+
+    def test_harvest_abort_failed_jobs_with_failed_jobs(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source = factories.HarvestSourceObj(**data_dict)
+        job = factories.HarvestJobObj(source=source)
+
+        # Simulate running job created 4 days ago
+        setattr(job, 'status', 'Running')
+        setattr(job, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=4))
+
+        model.Session.commit()
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+        result = get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3})
+
+        job = harvest_model.HarvestJob.get(job.id)
+
+        assert job.status in ('Finished', 'Aborted')
+        assert job.source_id == source.id
+        assert 'Aborted jobs: 1' in result
+
+    def test_harvest_abort_failed_jobs_with_include_source(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source1 = factories.HarvestSourceObj(**data_dict)
+        job1 = factories.HarvestJobObj(source=source1)
+
+        data_dict['name'] = 'another-source'
+        data_dict['url'] = 'http://another-url'
+        source2 = factories.HarvestSourceObj(**data_dict)
+        job2 = factories.HarvestJobObj(source=source2)
+
+        # Simulate running job created 4 and 5 days ago
+        setattr(job1, 'status', 'Running')
+        setattr(job1, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=4))
+        setattr(job2, 'status', 'Running')
+        setattr(job2, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=5))
+
+        model.Session.commit()
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+
+        # include first source with failed job so only job1 will be aborted
+        result = get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3, 'include': source1.id})
+
+        job1 = harvest_model.HarvestJob.get(job1.id)
+        job2 = harvest_model.HarvestJob.get(job2.id)
+
+        assert job1.status in ('Finished', 'Aborted')
+        assert job1.source_id == source1.id
+        assert job2.status in 'Running'
+        assert job2.source_id == source2.id
+        assert 'Aborted jobs: 1' in result
+
+    def test_harvest_abort_failed_jobs_with_exclude_source(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source1 = factories.HarvestSourceObj(**data_dict)
+        job1 = factories.HarvestJobObj(source=source1)
+
+        data_dict['name'] = 'another-source'
+        data_dict['url'] = 'http://another-url'
+        source2 = factories.HarvestSourceObj(**data_dict)
+        job2 = factories.HarvestJobObj(source=source2)
+
+        # Simulate running job created 4 and 5 days ago
+        setattr(job1, 'status', 'Running')
+        setattr(job1, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=4))
+        setattr(job2, 'status', 'Running')
+        setattr(job2, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=5))
+
+        model.Session.commit()
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+
+        # exclude first source with failed job so it's must still be Running
+        result = get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3, 'exclude': source1.id})
+
+        job1 = harvest_model.HarvestJob.get(job1.id)
+        job2 = harvest_model.HarvestJob.get(job2.id)
+
+        assert job1.status == 'Running'
+        assert job1.source_id == source1.id
+        assert job2.status in ('Finished', 'Aborted')
+        assert job2.source_id == source2.id
+        assert 'Aborted jobs: 1' in result
+
+    def test_harvest_abort_failed_jobs_with_include_and_exclude(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source = factories.HarvestSourceObj(**data_dict)
+        job = factories.HarvestJobObj(source=source)
+
+        # Simulate running job created 4 days ago
+        setattr(job, 'status', 'Running')
+        setattr(job, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=4))
+
+        model.Session.commit()
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+        # include must prevaild over exclude
+        result = get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3, 'exclude': source.id, 'include': source.id})
+
+        job = harvest_model.HarvestJob.get(job.id)
+
+        assert job.status in ('Finished', 'Aborted')
+        assert job.source_id == source.id
+        assert 'Aborted jobs: 1' in result
+
+    def test_harvest_abort_failed_jobs_with_source_frequency(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source = factories.HarvestSourceObj(**data_dict)
+        job = factories.HarvestJobObj(source=source)
+
+        # Simulate running job created 4 days ago
+        setattr(job, 'status', 'Running')
+        setattr(job, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=4))
+        # set source update frequency to biweekly
+        # job will be aborted if it's runs more then 2 weeks
+        setattr(source, 'frequency', 'BIWEEKLY')
+        model.Session.commit()
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+        result = get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3})
+
+        job = harvest_model.HarvestJob.get(job.id)
+
+        assert job.status == 'Running'
+        assert job.source_id == source.id
+        assert 'Aborted jobs: 0' in result
+    
+    def test_harvest_abort_failed_jobs_with_unknown_frequency(self):
+        # prepare
+        data_dict = SOURCE_DICT.copy()
+        source = factories.HarvestSourceObj(**data_dict)
+        job = factories.HarvestJobObj(source=source)
+
+        # Simulate running job created 4 days ago
+        setattr(job, 'status', 'Running')
+        setattr(job, 'created', datetime.datetime.utcnow()-datetime.timedelta(days=4))
+        # set unknown update frequency
+        setattr(source, 'frequency', 'YEARLY')
+        model.Session.commit()
+
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+
+        with pytest.raises(Exception) as e:
+            toolkit.get_action('harvest_abort_failed_jobs')(
+            context, {'life_span': 3})
+
     def test_harvest_source_create_twice_with_unique_url(self):
         data_dict = SOURCE_DICT.copy()
         factories.HarvestSourceObj(**data_dict)

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -1,5 +1,5 @@
 import json
-
+import datetime
 import pytest
 
 from ckan import plugins as p
@@ -473,7 +473,7 @@ class TestActions():
         assert job.status == 'Running'
         assert job.source_id == source.id
         assert 'Aborted jobs: 0' in result
-    
+
     def test_harvest_abort_failed_jobs_with_unknown_frequency(self):
         # prepare
         data_dict = SOURCE_DICT.copy()
@@ -490,9 +490,9 @@ class TestActions():
         context = {'model': model, 'session': model.Session,
                    'ignore_auth': True, 'user': ''}
 
-        with pytest.raises(Exception) as e:
-            toolkit.get_action('harvest_abort_failed_jobs')(
-            context, {'life_span': 3})
+        with pytest.raises(Exception):
+            get_action('harvest_abort_failed_jobs')(
+                context, {'life_span': 3})
 
     def test_harvest_source_create_twice_with_unique_url(self):
         data_dict = SOURCE_DICT.copy()

--- a/ckanext/harvest/utils.py
+++ b/ckanext/harvest/utils.py
@@ -228,6 +228,20 @@ def clear_harvest_source_history(source_id):
             len(cleared_sources_dicts))
 
 
+def abort_failed_jobs(job_life_span, include, exclude):
+    context = {
+        "model": model,
+        "user": _admin_user()["name"],
+        "session": model.Session,
+    }
+    result = tk.get_action("harvest_abort_failed_jobs")(context, {
+        "life_span": job_life_span,
+        "include": include,
+        "exclude": exclude
+    })
+    print(result)
+
+
 def purge_queues():
     from ckanext.harvest.queue import purge_queues as purge
 


### PR DESCRIPTION
Sometimes, we encounter the situation when job is in a "limbo state". Situation, when the job has run with errors but the harvester run command will not mark it as finished, and therefore you cannot run another job. This PR comes to abort such jobs if they are runs too long (depends on source update frequency). We planning to run it right before harvest run, to be able reharvest source if it's job ends up with error.

We used clearsource_history command to get rid of hanged jobs before and it was erroneous decision.

For example, `paster harvester abort_failed_jobs 3 -c /etc/ckan/default/production.ini` going to abort all jobs working longer then it's source update frequency (daily, weekly, monthly etc) or if update frequency is manual or always, longer then 3 days. 