### PR TITLE
Travis fix for Postgres 10

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -31,6 +31,20 @@ fi
 
 python setup.py develop
 
+if (( $CKAN_MINOR_VERSION < 8 )) && (( $PYTHON_MAJOR_VERSION == 2 ))
+then
+    echo "Hack to get CKAN 2.6 / 2.7 to work with Postgres 10..."
+    # because Postgres 10 is what Travis' Ubuntu image gives us now
+    sed -i -e 's/psycopg2==.*/psycopg2==2.8.2/' requirements.txt
+    sed -i -e 's/except sqlalchemy.exc.InternalError:/except (sqlalchemy.exc.InternalError, sqlalchemy.exc.DBAPIError):/' ckan/config/environment.py
+    if (( $CKAN_MINOR_VERSION == 7 ))
+    then
+        sed -i -e 's/ connection.connection,/ connection.connection.connection,/' ckanext/datastore/backend/postgres.py
+    else
+        sed -i -e 's/ connection.connection,/ connection.connection.connection,/' ckanext/datastore/db.py
+    fi
+fi
+
 if (( $CKAN_MINOR_VERSION >= 9 )) && (( $PYTHON_MAJOR_VERSION == 2 ))
 then
     pip install -r requirements-py2.txt


### PR DESCRIPTION
Without this PR, when testing CKAN 2.6 and 2.7 these days, you get [this
error on Travis](https://travis-ci.org/github/ckan/ckanext-harvest/jobs/667788749):
```
  Collecting psycopg2==2.4.5 (from -r requirements.txt (line 34))
  Downloading https://files.pythonhosted.org/packages/36/77/894a5dd9f3f55cfc85682d3e6473ee5103d8d418b95baf4019fad3ffa026/psycopg2-2.4.5.tar.gz (719kB)
    100% |████████████████████████████████| 727kB 2.2MB/s
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '10.1'
```
I'm not quite sure why Postgres 10 is found, because the image claims to be running Postgres 9.2 in the logs:
```
Pre-installed PostgreSQL versions
9.2.24
9.3.20
9.4.15
9.5.10
9.6.6
...
# line 422ish
 * Stopping PostgreSQL 9.2 database server        * Stopping PostgreSQL 9.3 database server        * Stopping PostgreSQL 9.4 database server        * Stopping PostgreSQL 9.5 database server        * Stopping PostgreSQL 9.6 database server        * Starting PostgreSQL 9.2 database server       sudo service postgresql start 9.2
```
And I don't know why this problem hasn't reared on ckanext-harvest builds before, although there hasn't been one for a month. I've had to do this hack on other extensions.

But whatever the reason, this PR fixes it 🤷‍♂ 