### PR TITLE
Improve harvest jobs notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ development.ini
 node_modules
 *.project
 .eggs
+.vscode/

--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ If you want to send an email when a **Harvest Job fails**, you can set the follo
 
     ckan.harvest.status_mail.errored = True
 
-If you want to send an email when **all Harvest Jobs finish** (whether or not it failed), you can set the following configuration option in the ini file:
+If you want to send an email when **completed Harvest Jobs finish** (whether or not it failed), you can set the following configuration option in the ini file:
 
     ckan.harvest.status_mail.all = True
 

--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ If you want to send an email when a **Harvest Job fails**, you can set the follo
 
     ckan.harvest.status_mail.errored = True
 
-If you want to send an email when **all Harvest Job finishes** (whether or not it failed), you can set the following configuration option in the ini file:
+If you want to send an email when **all Harvest Jobs finish** (whether or not it failed), you can set the following configuration option in the ini file:
 
     ckan.harvest.status_mail.all = True
 

--- a/README.rst
+++ b/README.rst
@@ -187,9 +187,13 @@ If you don't specify this setting, the default will be number-sequence.
 Send error mails when harvesting fails (optional)
 =================================================
 
-If you want to send an email when a Harvest Job fails, you can set the following configuration option in the ini file:
+If you want to send an email when a **Harvest Job fails**, you can set the following configuration option in the ini file:
 
     ckan.harvest.status_mail.errored = True
+
+If you want to send an email when **all Harvest Job finishes** (whether or not it failed), you can set the following configuration option in the ini file:
+
+    ckan.harvest.status_mail.all = True
 
 That way, all CKAN Users who are declared as Sysadmins will receive the Error emails at their configured email address. If the Harvest-Source of the failing Harvest-Job belongs to an organization, the error-mail will also be sent to the organization-members who have the admin-role if their E-Mail is configured.
 

--- a/README.rst
+++ b/README.rst
@@ -881,6 +881,35 @@ following steps with the one you are using.
    This particular example will perform clean-up each day at 05 AM.
    You can tweak the value according to your needs.
 
+Extensible actions
+==================
+
+Recipients on harvest jobs notifications
+----------------------------------------
+
+:code:`harvest_get_notifications_recipients`: you can *chain* this action from another extension to change 
+the recipients for harvest jobs notifications.
+
+.. code-block:: python
+
+  @toolkit.chained_action
+  def harvest_get_notifications_recipients(up_func, context, data_dict):
+      """ Harvester plugin notify by default about harvest jobs only to 
+              admin users of the related organization.
+              Also allow to add custom recipients with this function.
+              
+          Return a list of dicts with name and email like
+              {'name': 'John', 'email': 'john@source.com'} """
+
+      recipients = up_func(context, data_dict)
+      new_recipients = []
+
+      # you custom logic to add new_recipients here
+      # new_recipients.append({'name': 'Harvester Admin', 'email': 'admin@harvester-team.com'})
+      # recipients += new_recipients
+      return recipients
+
+
 Tests
 =====
 
@@ -900,6 +929,7 @@ Here are some common errors and solutions:
 
 * ``(OperationalError) near "SET": syntax error``
   You are testing with SQLite as the database, but the CKAN Harvester needs PostgreSQL. Specify test-core.ini instead of test.ini.
+
 
 Harvest API
 =====

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -666,7 +666,7 @@ def harvest_jobs_run(context, data_dict):
                     notify_all = toolkit.asbool(config.get('ckan.harvest.status_mail.all'))
                     notify_errors = toolkit.asbool(config.get('ckan.harvest.status_mail.errored'))
                     last_job_errors = status['last_job']['stats'].get('errored', 0)
-                    log.info('Notifications: All:{} On error:{} Errors:{}'.format(notify_all, notify_errors, last_job_errors))
+                    log.debug('Notifications: All:{} On error:{} Errors:{}'.format(notify_all, notify_errors, last_job_errors))
                     
                     if last_job_errors > 0 and (notify_all or notify_errors):
                         send_error_email(context, job_obj.source.id, status)
@@ -815,7 +815,7 @@ def get_recipients(context, source_id):
             data_dict = {'source_id': source_id}
             new_recipients = fn(context, data_dict)
             if len(new_recipients) > 0:
-                log.info('New recipients added to notification: {}'.format(new_recipients))
+                log.debug('New recipients added to notification: {}'.format(new_recipients))
                 recipients += new_recipients
     
     return recipients

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -670,13 +670,10 @@ def harvest_jobs_run(context, data_dict):
                     last_job_errors = status['last_job']['stats'].get('errored', 0)
                     log.info('Notifications: All:{} On error:{} Errors:{}'.format(notify_all, notify_errors, last_job_errors))
                     
-                    if notify_all:
-                        if last_job_errors > 0:
-                            send_error_email(context, job_obj.source_id, status)
-                        else:
-                            send_summary_email(context, job_obj.source.id, status)
-                    elif notify_errors and last_job_errors > 0:
+                    if last_job_errors > 0 and (notify_all or notify_errors):
                         send_error_email(context, job_obj.source.id, status)
+                    elif notify_all:
+                        send_summary_email(context, job_obj.source.id, status)
                 else:
                     log.debug('Ongoing job:%s source:%s',
                               job['id'], job['source_id'])

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -38,7 +38,6 @@ from ckanext.harvest.logic.action.get import (
 
 import ckan.lib.mailer as mailer
 from itertools import islice
-from ckan.lib.base import render_jinja2
 
 log = logging.getLogger(__name__)
 
@@ -746,7 +745,7 @@ def get_mail_extra_vars(context, source_id, status):
 
 def prepare_summary_mail(context, source_id, status):
     extra_vars = get_mail_extra_vars(context, source_id, status)
-    body = render_jinja2('emails/summary_email.txt', extra_vars)
+    body = toolkit.render('emails/summary_email.txt', extra_vars)
     subject = '{} - Harvesting Job Successful - Summary Notification'\
                   .format(config.get('ckan.site_title'))
     
@@ -754,7 +753,7 @@ def prepare_summary_mail(context, source_id, status):
 
 def prepare_error_mail(context, source_id, status):
     extra_vars = get_mail_extra_vars(context, source_id, status)
-    body = render_jinja2('emails/error_email.txt', extra_vars)
+    body = toolkit.render('emails/error_email.txt', extra_vars)
     subject = '{} - Harvesting Job - Error Notification'\
               .format(config.get('ckan.site_title'))
 

--- a/ckanext/harvest/logic/auth/get.py
+++ b/ckanext/harvest/logic/auth/get.py
@@ -132,3 +132,8 @@ def harvesters_info_show(context, data_dict):
         Everybody can do it
     '''
     return {'success': True}
+
+
+def harvest_get_notifications_recipients(context, data_dict):
+   # Only sysadmins can access this
+    return {'success': False}

--- a/ckanext/harvest/templates/emails/error_email.txt
+++ b/ckanext/harvest/templates/emails/error_email.txt
@@ -1,0 +1,33 @@
+This is a failure notification of the latest harvest job ({{ job_url }}) set-up in {{ site_url }}.
+
+Harvest Source: {{ harvest_source_title }}
+Harvest Configuration: {{ harvest_configuration | safe }}
+
+Organization: {{ organization }}
+
+Harvest Job Id: {{ job_id }}
+Created: {{ job_created }}
+Finished: {{ job_finished }}
+
+Records in Error: {{ records_in_error }}
+Records Added: {{ records_added }}
+Records Updated: {{ records_updated }}
+Records Deleted: {{ records_deleted }}
+
+{{ error_summary_title }}
+ - {{ errors|length }} errors
+{{ job_errors_title }}: {{ job_errors|length }}
+{% for error in job_errors %}
+    - {{ error }} {% endfor %}
+
+{{ obj_errors_title }}: {{ obj_errors|length }}
+{% for error in obj_errors %}
+    - {{ error }} {% endfor %}
+
+Total packages: {{ packages|length }}
+{% for package in packages %}
+    - {{ package }}{% endfor %}
+
+--
+You are receiving this email because you are currently set-up as Administrator for {{ site_url }}.
+Please do not reply to this email as it was sent from a non-monitored address.

--- a/ckanext/harvest/templates/emails/error_email.txt
+++ b/ckanext/harvest/templates/emails/error_email.txt
@@ -1,8 +1,8 @@
-This is a failure notification of the latest harvest job ({{ job_url }}) set-up in {{ site_url }}.
+This is a failure notification of the latest harvest job set-up in {{ site_url }}. 
+Job URL: {{ job_url }}
 
 Harvest Source: {{ harvest_source_title }}
 Harvest Configuration: {{ harvest_configuration | safe }}
-
 Organization: {{ organization }}
 
 Harvest Job Id: {{ job_id }}
@@ -14,20 +14,14 @@ Records Added: {{ records_added }}
 Records Updated: {{ records_updated }}
 Records Deleted: {{ records_deleted }}
 
-{{ error_summary_title }}
- - {{ errors|length }} errors
+{{ error_summary_title }}: {{ errors|length }} errors
+
 {{ job_errors_title }}: {{ job_errors|length }}
 {% for error in job_errors %}
     - {{ error }} {% endfor %}
-
 {{ obj_errors_title }}: {{ obj_errors|length }}
 {% for error in obj_errors %}
     - {{ error }} {% endfor %}
-
-Total packages: {{ packages|length }}
-{% for package in packages %}
-    - {{ package }}{% endfor %}
-
 --
 You are receiving this email because you are currently set-up as Administrator for {{ site_url }}.
 Please do not reply to this email as it was sent from a non-monitored address.

--- a/ckanext/harvest/templates/emails/summary_email.txt
+++ b/ckanext/harvest/templates/emails/summary_email.txt
@@ -1,0 +1,33 @@
+This is a summary of the latest harvest job ({{ job_url }}) set-up in {{ site_url }}.
+
+Harvest Source: {{ harvest_source_title }}
+Harvest Configuration: {{ harvest_configuration | safe }}
+
+Organization: {{ organization }}
+
+Harvest Job Id: {{ job_id }}
+Created: {{ job_created }}
+Finished: {{ job_finished }}
+
+Records in Error: {{ records_in_error }}
+Records Added: {{ records_added }}
+Records Updated: {{ records_updated }}
+Records Deleted: {{ records_deleted }}
+
+{{ error_summary_title }}
+ - {{ errors|length }} errors
+{{ job_errors_title }}: {{ job_errors|length }}
+{% for error in job_errors %}
+    - {{ error }} {% endfor %}
+
+{{ obj_errors_title }}: {{ obj_errors|length }}
+{% for error in obj_errors %}
+    - {{ error }} {% endfor %}
+
+Total packages: {{ packages|length }}
+{% for package in packages %}
+    - {{ package }}{% endfor %}
+
+--
+You are receiving this email because you are currently set-up as Administrator for {{ site_url }}.
+Please do not reply to this email as it was sent from a non-monitored address.

--- a/ckanext/harvest/templates/emails/summary_email.txt
+++ b/ckanext/harvest/templates/emails/summary_email.txt
@@ -1,4 +1,5 @@
-This is a summary of the latest harvest job ({{ job_url }}) set-up in {{ site_url }}.
+This is a summary of the latest harvest job set-up in {{ site_url }}.
+Job URL: {{ job_url }}
 
 Harvest Source: {{ harvest_source_title }}
 Harvest Configuration: {{ harvest_configuration | safe }}
@@ -14,8 +15,7 @@ Records Added: {{ records_added }}
 Records Updated: {{ records_updated }}
 Records Deleted: {{ records_deleted }}
 
-{{ error_summary_title }}
- - {{ errors|length }} errors
+{{ error_summary_title }}: {{ errors|length }} errors
 {{ job_errors_title }}: {{ job_errors|length }}
 {% for error in job_errors %}
     - {{ error }} {% endfor %}
@@ -23,10 +23,6 @@ Records Deleted: {{ records_deleted }}
 {{ obj_errors_title }}: {{ obj_errors|length }}
 {% for error in obj_errors %}
     - {{ error }} {% endfor %}
-
-Total packages: {{ packages|length }}
-{% for package in packages %}
-    - {{ package }}{% endfor %}
 
 --
 You are receiving this email because you are currently set-up as Administrator for {{ site_url }}.


### PR DESCRIPTION
Fixes #406 (and related to [GSA#315](https://github.com/GSA/datagov-ckan-multi/issues/315))

 - Added new config `ckan.harvest.status_mail.all` to notify all finished jobs.
   - README updated
 - Text templates were added for emails and variables were configured to fill it
 - Tests updated and [green at CI](https://travis-ci.org/github/ckan/ckanext-harvest/builds/696512648) for CKAN 2.6, 2.7 and 2.8. Master is not working (as in `master`)
 - Allow plugins to add custom recipients by adding the `IAction: add_extra_notification_recipients` [here](https://github.com/avdata99/ckanext-harvest/blob/406_notifications/ckanext/harvest/logic/action/update.py#L737-L745)