### PR TITLE
Indexes for harvest tables

### DIFF
--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -79,6 +79,14 @@ def setup():
         if "harvest_job_id_idx" not in index_names:
             log.debug('Creating index for harvest_object')
             Index("harvest_job_id_idx", harvest_object_table.c.harvest_job_id).create()
+        
+        if "harvest_source_id_idx" not in index_names:
+            log.debug('Creating index for harvest source')
+            Index("harvest_source_id_idx", harvest_object_table.c.harvest_source_id).create()
+        
+        if "package_id_idx" not in index_names:
+            log.debug('Creating index for package')
+            Index("package_id_idx", harvest_object_table.c.package_id).create()
 
 
 class HarvestError(Exception):
@@ -288,6 +296,8 @@ def define_harvester_tables():
         # report_status: 'added', 'updated', 'not modified', 'deleted', 'errored'
         Column('report_status', types.UnicodeText, nullable=True),
         Index('harvest_job_id_idx', 'harvest_job_id'),
+        Index('harvest_source_id_idx', 'harvest_source_id'),
+        Index('package_id_idx', 'package_id'),
     )
 
     # New table

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -88,6 +88,10 @@ def setup():
             log.debug('Creating index for package')
             Index("package_id_idx", harvest_object_table.c.package_id).create()
         
+        if "guid_idx" not in index_names:
+            log.debug('Creating index for guid')
+            Index("guid_idx", harvest_object_table.c.guid).create()
+        
         index_names = [index['name'] for index in inspector.get_indexes("harvest_object_extra")]
         if "harvest_object_id_idx" not in index_names:
             log.debug('Creating index for harvest_object_extra')
@@ -303,6 +307,7 @@ def define_harvester_tables():
         Index('harvest_job_id_idx', 'harvest_job_id'),
         Index('harvest_source_id_idx', 'harvest_source_id'),
         Index('package_id_idx', 'package_id'),
+        Index('guid_idx', 'guid'),
     )
 
     # New table

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -87,6 +87,11 @@ def setup():
         if "package_id_idx" not in index_names:
             log.debug('Creating index for package')
             Index("package_id_idx", harvest_object_table.c.package_id).create()
+        
+        index_names = [index['name'] for index in inspector.get_indexes("harvest_object_extra")]
+        if "harvest_object_id_idx" not in index_names:
+            log.debug('Creating index for harvest_object_extra')
+            Index("harvest_object_id_idx", harvest_object_extra_table.c.harvest_object_id).create()
 
 
 class HarvestError(Exception):
@@ -308,6 +313,7 @@ def define_harvester_tables():
         Column('harvest_object_id', types.UnicodeText, ForeignKey('harvest_object.id')),
         Column('key', types.UnicodeText),
         Column('value', types.UnicodeText),
+        Index('harvest_object_id_idx', 'harvest_object_id'),
     )
 
     # New table


### PR DESCRIPTION
# Indexes for harvest DB tables

We detect some slow queries when we try to access to harvest tables.
(related to issue #232 and PR #233)

## Environment

We use a lot of harvesting

```sql
select count(id) from harvest_source;
 count 
-------
   815

select count(id) from harvest_object;
 count  
--------
 333618

Select count(id) from harvest_object_extra;
  count  
---------
 1459843
```
## Slow queries

Query to measure slow queries:
```sql
SELECT 
  pid, age(query_start, clock_timestamp()), state, usename, query  
FROM 
  pg_stat_activity 
WHERE 
  query NOT ILIKE '%pg_stat_activity%' 
ORDER BY 
  query_start desc;
```
Here a few examples of queries that **take more than 15 seconds**:

```sql
SELECT 
    harvest_object.id AS harvest_object_id, 
    harvest_object.guid AS harvest_object_guid, 
    harvest_object.current AS harvest_object_current, 
    harvest_object.gathered AS harvest_object_gathered, 
    harvest_object.fetch_started AS harvest_object_fetch_started, 
    harvest_object.content AS harvest_object_content, 
    harvest_object.fetch_finished AS harvest_object_fetch_finished, 
    harvest_object.import_started AS harvest_object_import_started, 
    harvest_object.import_finished AS harvest_object_import_finished, 
    harvest_object.state AS harvest_object_state, 
    harvest_object.metadata_modified_date AS harvest_object_metadata_modified_date, 
    harvest_object.retry_times AS harvest_object_retry_times, 
    harvest_object.harvest_job_id AS harvest_object_harvest_job_id, 
    harvest_object.harvest_source_id AS harvest_object_harvest_source_id, 
    harvest_object.package_id AS harvest_object_package_id, 
    harvest_object.report_status AS harvest_object_report_status 

    FROM 
        harvest_object 
    WHERE 
        harvest_object.package_id = '5e58d18c-52dc-4e45-994e-936badae621d';
``` 

`harvest_object.package_id` requires an index

```sql
SELECT 
    harvest_object_extra.id AS harvest_object_extra_id,
    harvest_object_extra.harvest_object_id AS harvest_object_extra_harvest_object_id, 
    harvest_object_extra.key AS harvest_object_extra_key, 
    harvest_object_extra.value AS harvest_object_extra_value
FROM 
    harvest_object_extra 
WHERE 
    '59e34a0b-d51f-4206-b8a2-c92f8cf073ef' = harvest_object_extra.harvest_object_id;
```

`harvest_object_extra.harvest_object_id` requires an index

```sql
SELECT 
    harvest_object.id AS harvest_object_id, 
    harvest_object.guid AS harvest_object_guid, 
    harvest_object.current AS harvest_object_current, 
    harvest_object.gathered AS harvest_object_gathered, 
    harvest_object.fetch_started AS harvest_object_fetch_started, 
    harvest_object.content AS harvest_object_content, 
    harvest_object.fetch_finished AS harvest_object_fetch_finished, 
    harvest_object.import_started AS harvest_object_import_started, 
    harvest_object.import_finished AS harvest_object_import_finished, 
    harvest_object.state AS harvest_object_state, 
    harvest_object.metadata_modified_date AS harvest_object_metadata_modified_date, 
    harvest_object.retry_times AS harvest_object_retry_times, 
    harvest_object.harvest_job_id AS harvest_object_harvest_job_id, 
    harvest_object.harvest_source_id AS harvest_object_harvest_source_id, 
    harvest_object.package_id AS harvest_object_package_id, 
    harvest_object.report_status AS harvest_object_report_status
FROM 
    harvest_object 
WHERE 
    harvest_object.guid = '26e15556166c521a2b0ea73431e2826fdbbb66'
```

`harvest_object.guid` requires an index

After this PR applied the queries **ran in a second**.
