### PR TITLE
Improve timeouts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,8 @@ The timeout value is in minutes, so 1440 represents 24 hours.
 Any jobs which are timed out will create an error message for the user to see.
 
 If you don't specify this setting, the default will be False and there will be no timeout on harvest jobs.
+This timeout value is compared to the completion time of the last object in the job.
+
 
 Command line interface
 ======================

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -613,9 +613,11 @@ def harvest_jobs_run(context, data_dict):
                 last_time = job_obj.get_last_action_time()
                 now = datetime.datetime.now()
                 if now - last_time > datetime.timedelta(minutes=int(timeout)):
-                    msg = 'Job timeout: Last object for job %s is taking longer than %s minutes' % (job['id'], timeout)
-                    log.error(msg)
-
+                    msg = 'Job {} timeout ({} minutes)\n'.format(job_obj.id, timeout)
+                    msg += '\tJob created: {}\n'.format(job_obj.created)
+                    msg += '\tJob gather finished: {}\n'.format(job_obj.created)
+                    msg += '\tJob last action time: {}\n'.format(last_time)
+                    
                     job_obj.status = u'Finished'
                     job_obj.finished = now
                     job_obj.save()

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -610,10 +610,7 @@ def harvest_jobs_run(context, data_dict):
         for job in jobs:
             job_obj = HarvestJob.get(job['id'])
             if timeout:
-                last_time = job_obj.get_last_completed_object_time()
-                if last_time is None:
-                    last_time = job_obj.created
-
+                last_time = job_obj.get_last_action_time()
                 now = datetime.datetime.now()
                 if now - last_time > datetime.timedelta(minutes=int(timeout)):
                     msg = 'Job timeout: Last object for job %s is taking longer than %s minutes' % (job['id'], timeout)

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -176,9 +176,13 @@ class HarvestJob(HarvestDomainObject):
         
         return query
     
-    def get_last_completed_object_time(self):
+    def get_last_action_time(self):
         last_object = self.get_last_finished_object()
-        return None if last_object is None else last_object.import_finished
+        if last_object is not None:
+            return last_object.import_finished
+        if self.gather_finished is not None:
+            return self.gather_finished
+        return self.created
 
     def get_gather_errors(self):
         query = Session.query(HarvestGatherError)\

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -137,6 +137,16 @@ class HarvestSource(HarvestDomainObject):
 
     def __str__(self):
         return self.__repr__().encode('ascii', 'ignore')
+    
+    def get_jobs(self, status=None):
+        """ get the running jobs for this source """
+        
+        query = Session.query(HarvestJob).filter(HarvestJob.source_id == self.id)
+
+        if status is not None:
+            query = query.filter(HarvestJob.status == status)
+
+        return query.all()
 
 
 class HarvestJob(HarvestDomainObject):
@@ -150,7 +160,32 @@ class HarvestJob(HarvestDomainObject):
        (``HarvestObjectError``) are stored in the ``harvest_object_error``
        table.
     '''
-    pass
+    
+    def get_last_finished_object(self):
+        ''' Determine the last finished object in this job
+            Helpful to know if a job is running or not and 
+              to avoid timeouts when the source is running
+        '''
+        
+        query = Session.query(HarvestObject)\
+                    .filter(HarvestObject.harvest_job_id == self.id)\
+                    .filter(HarvestObject.state == "COMPLETE")\
+                    .filter(HarvestObject.import_finished.isnot(None))\
+                    .order_by(HarvestObject.import_finished.desc())\
+                    .first()
+        
+        return query
+    
+    def get_last_completed_object_time(self):
+        last_object = self.get_last_finished_object()
+        return None if last_object is None else last_object.import_finished
+
+    def get_gather_errors(self):
+        query = Session.query(HarvestGatherError)\
+                    .filter(HarvestGatherError.harvest_job_id == self.id)\
+                    .order_by(HarvestGatherError.created.desc())
+        
+        return query.all()
 
 
 class HarvestObject(HarvestDomainObject):

--- a/ckanext/harvest/tests/test_timeouts.py
+++ b/ckanext/harvest/tests/test_timeouts.py
@@ -26,7 +26,7 @@ class TestModelFunctions:
         ob3 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=15)
         
         assert_equal(job.get_last_finished_object(), ob2)
-        assert_equal(job.get_last_completed_object_time(), ob2.import_finished)
+        assert_equal(job.get_last_action_time(), ob2.import_finished)
 
         gather_errors = self.run(timeout=3, source=source, job=job) 
         assert_equal(len(gather_errors), 1)
@@ -43,12 +43,32 @@ class TestModelFunctions:
         ob3 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=15)
         
         assert_equal(job.get_last_finished_object(), ob2)
-        assert_equal(job.get_last_completed_object_time(), ob2.import_finished)
+        assert_equal(job.get_last_action_time(), ob2.import_finished)
 
         gather_errors = self.run(timeout=7, source=source, job=job) 
         assert_equal(len(gather_errors), 0)
         assert_equal(job.status, 'Finished')
-        
+    
+    def test_no_objects_job(self):
+        """ Test a job that don't raise timeout """
+        _, job = self.get_source()
+
+        job.gather_finished = datetime.utcnow()
+        job.save()
+
+        assert_equal(job.get_last_finished_object(), None)
+        assert_equal(job.get_last_action_time(), job.gather_finished)
+
+    def test_no_gathered_job(self):
+        """ Test a job that don't raise timeout """
+        _, job = self.get_source()
+
+        job.gather_finished = None
+        job.save()
+
+        assert_equal(job.get_last_finished_object(), None)
+        assert_equal(job.get_last_action_time(), job.created)
+
     def run(self, timeout, source, job):
         """ Run the havester_job_run and return the errors """
 

--- a/ckanext/harvest/tests/test_timeouts.py
+++ b/ckanext/harvest/tests/test_timeouts.py
@@ -1,0 +1,117 @@
+from datetime import datetime, timedelta
+from nose.tools import assert_equal, assert_in
+import pytest
+from ckan.tests import factories as ckan_factories
+from ckan import model
+from ckan.lib.base import config
+from ckan.plugins.toolkit import get_action
+from ckanext.harvest.model import HarvestSource, HarvestJob, HarvestObject
+from ckanext.harvest.tests import factories as harvest_factories
+from ckanext.harvest.logic import HarvestJobExists
+
+
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'harvest_setup', 'clean_queues')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest test_action_harvester')
+class TestModelFunctions:
+    
+    def test_timeout_jobs(self):
+        """ Create harvest spurce, job and objects
+            Validate we read the last object fished time
+            Validate we raise timeout in harvest_jobs_run_action
+            """
+        source, job = self.get_source()
+        
+        ob1 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=10)
+        ob2 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=5)
+        ob3 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=15)
+        
+        assert_equal(job.get_last_finished_object(), ob2)
+        assert_equal(job.get_last_completed_object_time(), ob2.import_finished)
+
+        gather_errors = self.run(timeout=3, source=source, job=job) 
+        assert_equal(len(gather_errors), 1)
+        assert_equal(job.status, 'Finished')
+        gather_error = gather_errors[0]
+        assert_in('timeout', gather_error.message)
+    
+    def test_no_timeout_jobs(self):
+        """ Test a job that don't raise timeout """
+        source, job = self.get_source()
+
+        ob1 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=10)
+        ob2 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=5)
+        ob3 = self.add_object(job=job, source=source, state='COMPLETE', minutes_ago=15)
+        
+        assert_equal(job.get_last_finished_object(), ob2)
+        assert_equal(job.get_last_completed_object_time(), ob2.import_finished)
+
+        gather_errors = self.run(timeout=7, source=source, job=job) 
+        assert_equal(len(gather_errors), 0)
+        assert_equal(job.status, 'Finished')
+        
+    def run(self, timeout, source, job):
+        """ Run the havester_job_run and return the errors """
+
+        # check timeout
+        context = {'model': model, 'session': model.Session,
+                   'ignore_auth': True, 'user': ''}
+
+        data_dict = {
+            'guid': 'guid',
+            'content': 'content',
+            'job_id': job.id,
+            'source_id': source.id
+        }
+
+        # prepare the job to run
+        job.gather_finished = datetime.utcnow()
+        job.save()
+
+        # run (we expect a timeout)
+        config['ckan.harvest.timeout'] = timeout
+        harvest_jobs_run_action = get_action('harvest_jobs_run')
+        harvest_jobs_run_action(context, data_dict)
+        
+        return job.get_gather_errors()
+
+    def get_source(self):
+
+        SOURCE_DICT = {
+            "url": "http://test.timeout.com",
+            "name": "test-source-timeout",
+            "title": "Test source timeout",
+            "notes": "Notes source timeout",
+            "source_type": "test-for-action",
+            "frequency": "MANUAL"
+        }
+        source = harvest_factories.HarvestSourceObj(**SOURCE_DICT)
+        try:
+            job = harvest_factories.HarvestJobObj(source=source)
+        except HarvestJobExists: # not sure why
+            job = source.get_jobs()[0]
+        
+        job.status = 'Running'
+        job.save()
+        
+        jobs = source.get_jobs(status='Running')
+        assert_in(job, jobs)
+
+        return source, job
+        
+    def add_object(self, job, source, state, minutes_ago):
+        now = datetime.utcnow()
+        name = 'dataset-{}-{}'.format(state.lower(), minutes_ago)
+        dataset = ckan_factories.Dataset(name=name)
+        obj = harvest_factories.HarvestObjectObj(
+            job=job,
+            source=source,
+            package_id=dataset['id'],
+            guid=dataset['id'],
+            content='{}',
+            # always is WAITING state=state,
+            )
+
+        obj.state = state
+        obj.import_finished = now - timedelta(minutes=minutes_ago)
+        obj.save()
+        return obj


### PR DESCRIPTION
Related to #417

This PR:
 - Change timeout detection (now we use last finished object time in a job instead `job.created`)
 - Add tests for timeout detection
 