### PR TITLE
Fix checking for harvest objects in fetch queue.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 Unreleased_
 ***********
 
+- Fix resubmitting harvest objects to Redis fetch queue #421
+
 ***********
 1.3.1_ - 2020-09-01
 ***********

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -170,12 +170,8 @@ def resubmit_objects():
     objects_in_queue = []
     fetch_routing_key = get_fetch_routing_key()
 
-    for i in range(redis.llen(fetch_routing_key)):
-        item = redis.lpop(fetch_routing_key)
-        objects_in_queue.append(
-            json.loads(item)['harvest_object_id']
-        )
-        redis.rpush(fetch_routing_key, item)
+    objects_in_queue = [json.loads(o)['harvest_object_id']
+                        for o in redis.lrange(fetch_routing_key, 0, -1)]
 
     for object_id, in waiting_objects:
         if object_id not in objects_in_queue:


### PR DESCRIPTION
The fetch queue is stored in redis as a list of harvest object ids. The previous code checked for individual harvest object ids in redis, and always found none. Therefore, every time the harvester run command was run, all ids of harvest objects in the WAITING state in the DB were re-added to the fetch queue.

Fixes #420. 