### PR TITLE
[#425] Extend harvester to support include/exclude filtering by tags

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,9 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 Unreleased_
 ***********
 
+Added
+-----
+- CKAN Harvester option to include/exclude tags #425
 
 ***********
 1.3.2_ - 2020-10-08

--- a/README.rst
+++ b/README.rst
@@ -441,6 +441,11 @@ field. The currently supported configuration options are:
 *   groups_filter_exclude: Exactly the same as organizations_filter_exclude but for
     groups.
 
+*   tags_filter_include: Exactly the same as organizations_filter_include but for
+    groups.
+
+*   tags_filter_exclude: Exactly the same as organizations_filter_exclude but for
+    groups.
 
 Here is an example of a configuration object (the one that must be entered in
 the configuration field)::

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -155,6 +155,11 @@ class CKANHarvester(HarvesterBase):
                 raise ValueError('Harvest configuration cannot contain both '
                                  'groups_filter_include and groups_filter_exclude')
 
+            if 'tags_filter_include' in config_obj \
+                    and 'tags_filter_exclude' in config_obj:
+                raise ValueError('Harvest configuration cannot contain both '
+                                 'tags_filter_include and tags_filter_exclude')
+
             if 'user' in config_obj:
                 # Check if user exists
                 context = {'model': model, 'user': toolkit.c.user}
@@ -211,6 +216,15 @@ class CKANHarvester(HarvesterBase):
         elif groups_filter_exclude:
             fq_terms.extend(
                 '-groups:%s' % group_name for group_name in groups_filter_exclude)
+
+        tags_filter_include = self.config.get('tags_filter_include', [])
+        tags_filter_exclude = self.config.get('tags_filter_exclude', [])
+        if tags_filter_include:
+            fq_terms.append(' OR '.join(
+                'tags:"%s"' % tag_name for tag_name in tags_filter_include))
+        elif tags_filter_exclude:
+            fq_terms.extend(
+                '-tags:"%s"' % tag_name for tag_name in tags_filter_exclude)
 
         # Ideally we can request from the remote CKAN only those datasets
         # modified since the last completely successful harvest.

--- a/ckanext/harvest/tests/harvesters/test_ckanharvester.py
+++ b/ckanext/harvest/tests/harvesters/test_ckanharvester.py
@@ -161,6 +161,24 @@ class TestCkanHarvester(object):
         assert 'dataset1-id' in results_by_guid
         assert mock_ckan.DATASETS[1]['id'] not in results_by_guid
 
+    def test_exclude_tags(self):
+        config = {'tags_filter_exclude': ['test-tag']}
+        results_by_guid = run_harvest(
+            url='http://localhost:%s' % mock_ckan.PORT,
+            harvester=CKANHarvester(),
+            config=json.dumps(config))
+        assert 'dataset1-id' not in results_by_guid
+        assert mock_ckan.DATASETS[1]['id'] in results_by_guid
+
+    def test_include_tags(self):
+        config = {'tags_filter_include': ['test-tag']}
+        results_by_guid = run_harvest(
+            url='http://localhost:%s' % mock_ckan.PORT,
+            harvester=CKANHarvester(),
+            config=json.dumps(config))
+        assert 'dataset1-id' in results_by_guid
+        assert mock_ckan.DATASETS[1]['id'] not in results_by_guid
+
     def test_remote_groups_create(self):
         config = {'remote_groups': 'create'}
         results_by_guid = run_harvest(


### PR DESCRIPTION
Added ability to include/exclude filter by tags as per organization/groups.
PR includes logic, CHANGELOG, README, tests