### PR TITLE
Optimize last error free job

### DIFF
--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -5,7 +5,7 @@ import re
 import uuid
 import six
 
-from sqlalchemy import exists
+from sqlalchemy import exists, and_
 from sqlalchemy.sql import update, bindparam
 
 from ckantoolkit import config
@@ -422,15 +422,15 @@ class HarvesterBase(SingletonPlugin):
                 .filter(
             ~exists().where(
                 HarvestGatherError.harvest_job_id == HarvestJob.id))
+                .join(HarvestObject,
+                      and_(HarvestObject.harvest_job_id == HarvestJob.id,
+                           HarvestObject.current == False,  # noqa: E712
+                           HarvestObject.report_status != 'not modified'),
+                      isouter=True)
+                .options(contains_eager=HarvestJob.objects)
                 .order_by(HarvestJob.gather_started.desc()))
         # now check them until we find one with no fetch/import errors
-        # (looping rather than doing sql, in case there are lots of objects
-        # and lots of jobs)
+        # if objects count is 0, job was error free
         for job in jobs:
-            for obj in job.objects:
-                if obj.current is False and \
-                        obj.report_status != 'not modified':
-                    # unsuccessful, so go onto the next job
-                    break
-            else:
+            if len(job.objects) == 0:
                 return job

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -423,11 +423,10 @@ class HarvesterBase(SingletonPlugin):
                 .filter(
             ~exists().where(
                 HarvestGatherError.harvest_job_id == HarvestJob.id))
-                .join(HarvestObject,
+                .outerjoin(HarvestObject,
                       and_(HarvestObject.harvest_job_id == HarvestJob.id,
                            HarvestObject.current == False,  # noqa: E712
-                           HarvestObject.report_status != 'not modified'),
-                      isouter=True)
+                           HarvestObject.report_status != 'not modified'))
                 .options(contains_eager(HarvestJob.objects))
                 .order_by(HarvestJob.gather_started.desc()))
         # now check them until we find one with no fetch/import errors

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -424,9 +424,9 @@ class HarvesterBase(SingletonPlugin):
             ~exists().where(
                 HarvestGatherError.harvest_job_id == HarvestJob.id))
                 .outerjoin(HarvestObject,
-                      and_(HarvestObject.harvest_job_id == HarvestJob.id,
-                           HarvestObject.current == False,  # noqa: E712
-                           HarvestObject.report_status != 'not modified'))
+                           and_(HarvestObject.harvest_job_id == HarvestJob.id,
+                                HarvestObject.current == False,  # noqa: E712
+                                HarvestObject.report_status != 'not modified'))
                 .options(contains_eager(HarvestJob.objects))
                 .order_by(HarvestJob.gather_started.desc()))
         # now check them until we find one with no fetch/import errors

--- a/ckanext/harvest/harvesters/base.py
+++ b/ckanext/harvest/harvesters/base.py
@@ -7,6 +7,7 @@ import six
 
 from sqlalchemy import exists, and_
 from sqlalchemy.sql import update, bindparam
+from sqlalchemy.orm import contains_eager
 
 from ckantoolkit import config
 
@@ -427,7 +428,7 @@ class HarvesterBase(SingletonPlugin):
                            HarvestObject.current == False,  # noqa: E712
                            HarvestObject.report_status != 'not modified'),
                       isouter=True)
-                .options(contains_eager=HarvestJob.objects)
+                .options(contains_eager(HarvestJob.objects))
                 .order_by(HarvestJob.gather_started.desc()))
         # now check them until we find one with no fetch/import errors
         # if objects count is 0, job was error free


### PR DESCRIPTION
last_error_free_job executes select query every time it accesses harvest objects belonging to the harvest job as they are lazily loaded. This results in inefficient cpu and memory use when there are lot of harvest jobs with errors in them.

This PR does eager query for harvest objects and does the filtering in the same query. If no harvest objects are returned for the job, the job is error free.