### PR TITLE
Validate before DB transaction boundary

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -11,6 +11,7 @@ from ckan import model
 from ckan.logic import ValidationError, NotFound, get_action
 from ckan.lib.helpers import json
 from ckan.plugins import toolkit
+import ckan.lib.plugins as lib_plugins
 
 from ckanext.harvest.model import HarvestObject
 from .base import HarvesterBase
@@ -546,6 +547,43 @@ class CKANHarvester(HarvesterBase):
                 resource.pop('revision_id', None)
 
             package_dict = self.modify_package_dict(package_dict, harvest_object)
+
+            # validate packages if needed
+            validate_packages = True
+            if validate_packages:
+                if 'type' not in package_dict:
+                    package_plugin = lib_plugins.lookup_package_plugin()
+                    try:
+                        # use first type as default if user didn't provide type
+                        package_type = package_plugin.package_types()[0]
+                    except (AttributeError, IndexError):
+                        package_type = 'dataset'
+                        # in case a 'dataset' plugin was registered w/o fallback
+                        package_plugin = lib_plugins.lookup_package_plugin(package_type)
+                    package_dict['type'] = package_type
+                else:
+                    package_plugin = lib_plugins.lookup_package_plugin(package_dict['type'])
+
+
+                errors = {}
+                # if package has been previously imported
+                try:
+                    existing_package_dict = self._find_existing_package(package_dict)
+
+                    if not 'metadata_modified' in package_dict or \
+                            package_dict['metadata_modified'] > existing_package_dict.get('metadata_modified'):
+                        schema = package_plugin.update_package_schema()
+                        data, errors = lib_plugins.plugin_validate(
+                            package_plugin, base_context, package_dict, schema, 'package_update')
+
+                except NotFound:
+
+                    schema = package_plugin.create_package_schema()
+                    data, errors = lib_plugins.plugin_validate(
+                        package_plugin, base_context, package_dict, schema, 'package_create')
+
+                if errors:
+                    raise ValidationError(errors)
 
             result = self._create_or_update_package(
                 package_dict, harvest_object, package_dict_form='package_show')


### PR DESCRIPTION
This code change is based on #312 and fixes a problem for harvest instances that implement their own validators.

The WAFs that we harvest often contain metadata records that fail our extra validation rules.   

Here's the behavior I'm seeing with ckanext-harvest version 1.3.3, when we harvest a WAF containing records that fail validation:  

* When the harvest queues have been newly started or purged, the harvest job is successfully marked as finished and an error email is sent.   
* A second harvest of the same WAF causes this stack trace in gather_err.log:

```
2021-05-18 09:31:21,153 DEBUG [ckanext.harvest.queue] Received harvest job id: 04c1c1db-087d-436b-88b1-ea9e910db1c3
Traceback (most recent call last):
  File "/usr/lib/ckan/default/bin/paster", line 8, in <module>
    sys.exit(run())
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/usr/lib/ckan/default/src/ckanext-harvest/ckanext/harvest/commands/harvester.py", line 235, in command
    utils.gather_consumer()
  File "/usr/lib/ckan/default/src/ckanext-harvest/ckanext/harvest/utils.py", line 336, in gather_consumer
    gather_callback(consumer, method, header, body)
  File "/usr/lib/ckan/default/src/ckanext-harvest/ckanext/harvest/queue.py", line 347, in gather_callback
    job = HarvestJob.get(id)
  File "/usr/lib/ckan/default/src/ckanext-harvest/ckanext/harvest/model/__init__.py", line 116, in get
    o = cls.filter(**kwds).first()
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2755, in first
    ret = list(self[0:1])
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2547, in __getitem__
    return list(res)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2855, in __iter__
    return self._execute_and_instances(context)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2876, in _execute_and_instances
    close_with_result=True)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2885, in _get_bind_args
    **kw
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/query.py", line 2867, in _connection_from_session
    conn = self.session.connection(**kw)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 998, in connection
    execution_options=execution_options)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 1003, in _connection_for_bind
    engine, execution_options)
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 382, in _connection_for_bind
    self._assert_active()
  File "/usr/lib/ckan/default/lib/python2.7/site-packages/sqlalchemy/orm/session.py", line 276, in _assert_active
    % self._rollback_exception
sqlalchemy.exc.InvalidRequestError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.DatabaseError) could not receive data from server: Connection timed out
 [SQL: 'INSERT INTO harvest_log (id, content, level, created) VALUES (%(id)s, %(content)s, %(level)s, %(created)s)'] [parameters: {'content': u'Received harvest job id: 04c1c1db-087d-436b-88b1-ea9e910db1c3', 'created': datetime.datetime(2021, 5, 18, 15, 31, 21, 155237), 'id': u'c4225513-9d7f-48ff-b9c5-4363d549054e', 'level': 'DEBUG'}]
```
This harvest job eventually times out, though sometimes 1-5 hours after the timeout value of 5 minutes that we have set. 

If, however, I purge the queues before the second harvest job, then the job finishes successfully and there is no stack trace.    

This PR will validate before create_or_update(), and I have verified that I no longer have to purge the harvest queues in order to keep getting harvest jobs marked as finished.   Instead, we get an error email each time.    Note that we prefer the repeat email behavior as we might otherwise forget that there is a problem that needs fixing with one of our records.