### PR TITLE
Harvest Source Extra Fields are not encoded into JSON appropriately

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -133,7 +133,7 @@ def harvest_source_extra_fields():
     for harvester in p.PluginImplementations(IHarvester):
         if not hasattr(harvester, 'extra_schema'):
             continue
-        fields[harvester.info()['name']] = harvester.extra_schema().keys()
+        fields[harvester.info()['name']] = list(harvester.extra_schema().keys())
     return fields
 
 


### PR DESCRIPTION
The dictionary types changed from py2 to py3 causing differences in how dictionaries are encoded into a JSON object.  The fix for py3 also works for py3... https://stackoverflow.com/questions/48374667/object-of-type-dict-items-is-not-json-serializable