### PR TITLE
Fix render function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 ***********
 Unreleased_
 ***********
+- Changes function calls to `render_jinja2` over to `render` as the former is
+  no longer used.
 
 ***********
 1.3.3_ - 2021-03-26

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -16,7 +16,7 @@ from ckan.plugins import toolkit, PluginImplementations
 from ckan.logic import get_action
 from ckanext.harvest.interfaces import IHarvester
 from ckan.lib.search.common import SearchIndexError, make_connection
-from ckan.lib.base import render_jinja2
+from ckan.lib.base import render
 
 from ckan.model import Package
 from ckan import logic
@@ -746,7 +746,7 @@ def get_mail_extra_vars(context, source_id, status):
 
 def prepare_summary_mail(context, source_id, status):
     extra_vars = get_mail_extra_vars(context, source_id, status)
-    body = render_jinja2('emails/summary_email.txt', extra_vars)
+    body = render('emails/summary_email.txt', extra_vars)
     subject = '{} - Harvesting Job Successful - Summary Notification'\
         .format(config.get('ckan.site_title'))
 
@@ -755,7 +755,7 @@ def prepare_summary_mail(context, source_id, status):
 
 def prepare_error_mail(context, source_id, status):
     extra_vars = get_mail_extra_vars(context, source_id, status)
-    body = render_jinja2('emails/error_email.txt', extra_vars)
+    body = render('emails/error_email.txt', extra_vars)
     subject = '{} - Harvesting Job - Error Notification'\
         .format(config.get('ckan.site_title'))
 


### PR DESCRIPTION
Removes a call to `render_jinja2`, which was removed in CKAN 2.9.