### PR TITLE
Allow GET requests to harvester.refresh

### DIFF
--- a/ckanext/harvest/views.py
+++ b/ckanext/harvest/views.py
@@ -72,7 +72,7 @@ harvester.add_url_rule(
 )
 harvester.add_url_rule("/" + utils.DATASET_TYPE_NAME + "/clear/<id>",
                        view_func=clear,
-                       methods=(u'POST', ))
+                       methods=(u'POST', u'GET'))
 harvester.add_url_rule(
     "/" + utils.DATASET_TYPE_NAME + "/<source>/job",
     view_func=job_list,

--- a/ckanext/harvest/views.py
+++ b/ckanext/harvest/views.py
@@ -61,7 +61,7 @@ harvester.add_url_rule(
 )
 harvester.add_url_rule("/" + utils.DATASET_TYPE_NAME + "/refresh/<id>",
                        view_func=refresh,
-                       methods=(u'POST', ))
+                       methods=(u'POST', u'GET'))
 harvester.add_url_rule(
     "/" + utils.DATASET_TYPE_NAME + "/admin/<id>",
     view_func=admin,


### PR DESCRIPTION
The "Reharvest" button in harvest source admin view returns a 404 because it performs a GET request and the blueprint doesn't cover them. Added GET to allowd methods to fix this.

Financed by Finland's open data portal opendata.fi. Find all Finnish open data at https://www.opendata.fi/en.
The Service is provided by the Digital and Population Data Services Agency (https://dvv.fi/en/).