### PR TITLE
CLI run-test without UnboundLocalVariable

### DIFF
--- a/ckanext/harvest/cli.py
+++ b/ckanext/harvest/cli.py
@@ -273,10 +273,10 @@ def run_test(ctx, id, force_import=None):
 
     """
     if force_import:
-        force_import_val = force_import.split('=')[-1]
+        force_import = force_import.split('=')[-1]
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
-        utils.run_test_harvester(id, force_import_val)
+        utils.run_test_harvester(id, force_import)
 
 
 @harvester.command("import")


### PR DESCRIPTION
The current `run-test` implementation raises the UnboundLocalVariable exception because of incorrect handling of `force-import` argument. 
The fix is quite trivial, don't think it will cause any questions