### PR TITLE
Replace Pylons routes for build_nav_icon

### DIFF
--- a/ckanext/harvest/templates/source/admin_base.html
+++ b/ckanext/harvest/templates/source/admin_base.html
@@ -58,7 +58,7 @@
 {% endblock %}
 
 {% block page_header_tabs %}
-  {{ h.build_nav_icon('{0}_admin'.format(c.dataset_type), _('Dashboard'), id=harvest_source.name, icon='dashboard') }}
-  {{ h.build_nav_icon('harvest_job_list'.format(c.dataset_type), _('Jobs'), source=harvest_source.name, icon='reorder') }}
-  {{ h.build_nav_icon('{0}_edit'.format(c.dataset_type), _('Edit'), id=harvest_source.name, icon='edit') }}
+  {{ h.build_nav_icon('harvester.admin', _('Dashboard'), id=harvest_source.name, icon='dashboard') }}
+  {{ h.build_nav_icon('harvester.job_list'.format(c.dataset_type), _('Jobs'), source=harvest_source.name, icon='reorder') }}
+  {{ h.build_nav_icon('{0}.edit'.format(c.dataset_type), _('Edit'), id=harvest_source.name, icon='edit') }}
 {% endblock %}

--- a/ckanext/harvest/templates/source/read_base.html
+++ b/ckanext/harvest/templates/source/read_base.html
@@ -47,8 +47,8 @@
         {% endblock %}
         <ul class="nav nav-tabs">
           {% block page_header_tabs %}
-            {{ h.build_nav_icon('{0}_read'.format(c.dataset_type), _('Datasets'), id=harvest_source.name, icon='sitemap') }}
-            {{ h.build_nav_icon('{0}_about'.format(c.dataset_type), _('About'), id=harvest_source.name, icon='info-sign') }}
+            {{ h.build_nav_icon('{0}.read'.format(c.dataset_type), _('Datasets'), id=harvest_source.name, icon='sitemap') }}
+            {{ h.build_nav_icon('harvester.about', _('About'), id=harvest_source.name, icon='info-sign') }}
           {% endblock %}
         </ul>
       </header>


### PR DESCRIPTION
Fix #476

I am not sure why `admin` and `about` require `harvester.` as prefix instead of the variable `dataset_type`, but it seems to work for me.

This PR does not replace all the Pylons routes: there are still a lot of deprecation warnings. This is just the bare minimum to make `ckanext-harvest` work with the current CKAN. I also prefer to send small fixes as they can be more easily reviewed instead of trying to replace all the routes at once.