### PR TITLE
Futureproof version check to work also on 3.0+

### DIFF
--- a/ckanext/harvest/templates/base.html
+++ b/ckanext/harvest/templates/base.html
@@ -3,7 +3,7 @@
 {% block styles %}
     {{ super() }}
 
-    {% set type = 'asset' if h.ckan_version().split('.')[1] | int >= 9 else 'resource' %}
+    {% set type = 'asset' if h.ckan_version().split('.')|map('int')|list >= [2, 9, 0] else 'resource' %}
     {% include 'harvest/snippets/harvest_' ~ type ~ '.html' %}
 
 {% endblock %}

--- a/ckanext/harvest/templates/source/new_source_form.html
+++ b/ckanext/harvest/templates/source/new_source_form.html
@@ -1,7 +1,7 @@
 {% import 'macros/form.html' as form %}
 
 
-{% set type = 'asset' if h.ckan_version().split('.')[1] | int >= 9 else 'resource' %}
+{% set type = 'asset' if h.ckan_version().split('.')|map('int')|list >= [2, 9, 0] else 'resource' %}
 {% include 'harvest/snippets/harvest_extra_field_' ~ type ~ '.html' %}
 
 <form id="source-new" class="form-horizontal dataset-form {{ h.bootstrap_version() }}" method="post" >


### PR DESCRIPTION
Coworker of mine noticed that version check would fail when the ckan version 3.0 is released as the minor version is no longer greater than 9, this updated check will also work on 3.0 and any patch releases which can be defined in the check.