### PR TITLE
Check 'email' field existence before use

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -454,7 +454,7 @@ def harvest_get_notifications_recipients(context, data_dict):
             member_details = p.toolkit.get_action(
                 'user_show')(context, {'id': member[0]})
 
-            if member_details['email']:
+            if member_details.get('email', None):
                 recipients.append({
                     'name': member_details['name'],
                     'email': member_details['email']


### PR DESCRIPTION
If a non-admin user runs a harvest job and an error email should be sent, the 'email' field will not be present in `member_details`.

So it seems best to include a guard against the 'email' field not being present before using it.

