### PR TITLE
Add the harvesters tab to ckan admin dashboard

### DIFF
--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -302,6 +302,12 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
             })
             # https://github.com/ckan/ckan/pull/4521
             config['ckan.legacy_route_mappings'] = json.dumps(mappings)
+            p.toolkit.add_ckan_admin_tab(
+            p.toolkit.config,
+            'harvest.search',
+            'Harvesters',
+            config_var='ckan.admin_tabs'
+        )
 
     # IActions
 


### PR DESCRIPTION
Add the `harvesters` tab for easier access as sysadmin though the `/harvest` endpoint is not behind authorization check. 