### PR TITLE
Allow full clear of completed jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 *.project
 .eggs
 .vscode/
+.idea/

--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     'HarvestObject', 'harvest_object_table',
     'HarvestGatherError', 'harvest_gather_error_table',
     'HarvestObjectError', 'harvest_object_error_table',
+    'HarvestObjectExtra', 'harvest_object_extra_table',
     'HarvestLog', 'harvest_log_table'
 ]
 
@@ -356,7 +357,7 @@ def define_harvester_tables():
         Column('state', types.UnicodeText, default=u'WAITING'),
         Column('metadata_modified_date', types.DateTime),
         Column('retry_times', types.Integer, default=0),
-        Column('harvest_job_id', types.UnicodeText, ForeignKey('harvest_job.id')),
+        Column('harvest_job_id', types.UnicodeText, ForeignKey('harvest_job.id', ondelete='SET NULL'), nullable=True),
         Column('harvest_source_id', types.UnicodeText, ForeignKey('harvest_source.id')),
         Column('package_id', types.UnicodeText, ForeignKey('package.id', deferrable=True),
                nullable=True),


### PR DESCRIPTION

The current behavior of the "source clear-history" command is to retain all job ids where some harvested dataset came from that job id.    This seems unnecessary, and for our CKAN instance, with many thousands of harvested datasets that get updated in small batches, it means that there is always a very long job history list.   

This PR will require a small 2-line change to the ckan/ckanext-spatial WAF harvesting code, to handle the case where a harvest job ID has been cleared.    It is possible that other harvesters will need small adjusts like this; I've only tested the WAF harvesting code because this is my organization's particular use case.

I have also made a suggested change to the options for this command, so that "keep currently running jobs" is always done.   It seems potentially confusing, possibly unhelpful, and unnecessary to clear the history of jobs that are still running.

I know that this initial PR version has failing tests.    I do not have testing set up on my current vagrant VM instance, and will try to fix the tests by looking at the Github tests output.  


Please feel free to suggest possible alternatives or edits.     Thank you!