### PR TITLE
Fix pagination for Dataset list on source page

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -56,7 +56,10 @@ def package_list_for_source(source_id):
 
     query = logic.get_action('package_search')(context, search_dict)
 
-    base_url = h.url_for('{0}_read'.format(DATASET_TYPE_NAME), id=source_id)
+    base_url = h.url_for(
+        '{0}_read'.format(DATASET_TYPE_NAME),
+        id=harvest_source['name']
+    )
 
     def pager_url(q=None, page=None):
         url = base_url


### PR DESCRIPTION
This is a fix for Dataset list on source page. Currently pagination links lead to /harvest/SOURCE_ID as a result redirect works according to CKAN logic and as a result it doesn't open the needed page.