### PR TITLE
Raise privileges to get email address information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ development.ini
 node_modules
 *.project
 .eggs
+.idea/
 .vscode/
+

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -450,9 +450,13 @@ def harvest_get_notifications_recipients(context, data_dict):
             'capacity': 'admin'
         })
 
+        # Get access to email address by running action as admin user
+        context['user'] = 'admin'
         for member in members:
-            member_details = p.toolkit.get_action(
-                'user_show')(context, {'id': member[0]})
+            member_details = p.toolkit.get_action('user_show')(context, {
+                   'id': member[0],
+                   'include_plugin_extras': True
+            })
 
             if member_details.get('email', None):
                 recipients.append({

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -436,11 +436,14 @@ def harvest_get_notifications_recipients(context, data_dict):
         model.User.sysadmin == True  # noqa: E712
     ).all()
 
+    # Send mail to all sysadmins with a non-empty email address
     for sysadmin in sysadmins:
-        recipients.append({
-            'name': sysadmin.name,
-            'email': sysadmin.email
-        })
+        email_address = sysadmin.email
+        if email_address and email_address.strip():
+            recipients.append({
+                'name': sysadmin.name,
+                'email': sysadmin.email
+            })
 
     # gather organization-admins
     if source.get('organization'):

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -454,7 +454,7 @@ def harvest_get_notifications_recipients(context, data_dict):
         })
 
         # Get access to email address by running action as admin user
-        context['user'] = 'admin'
+        context['user'] = p.toolkit.get_action('get_site_user')({'ignore_auth': True})['name']
         for member in members:
             member_details = p.toolkit.get_action('user_show')(context, {
                    'id': member[0],

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -456,7 +456,8 @@ def harvest_get_notifications_recipients(context, data_dict):
         # Get access to email address by running action as admin user
         context['user'] = p.toolkit.get_action('get_site_user')({'ignore_auth': True})['name']
         for member in members:
-            member_details = p.toolkit.get_action('user_show')(context, {'id': member[0]})
+            member_details = p.toolkit.get_action(
+                'user_show')(context, {'id': member[0]})
 
             email_address = member_details.get('email', None)
             if email_address and email_address.strip():

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -456,10 +456,7 @@ def harvest_get_notifications_recipients(context, data_dict):
         # Get access to email address by running action as admin user
         context['user'] = p.toolkit.get_action('get_site_user')({'ignore_auth': True})['name']
         for member in members:
-            member_details = p.toolkit.get_action('user_show')(context, {
-                   'id': member[0],
-                   'include_plugin_extras': True
-            })
+            member_details = p.toolkit.get_action('user_show')(context, {'id': member[0]})
 
             email_address = member_details.get('email', None)
             if email_address and email_address.strip():

--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -461,10 +461,11 @@ def harvest_get_notifications_recipients(context, data_dict):
                    'include_plugin_extras': True
             })
 
-            if member_details.get('email', None):
+            email_address = member_details.get('email', None)
+            if email_address and email_address.strip():
                 recipients.append({
                     'name': member_details['name'],
-                    'email': member_details['email']
+                    'email': email_address
                 })
 
     return recipients


### PR DESCRIPTION
There are two changes needed to get access to a user's email address for harvester emails.

The first change gives privileged access to a user's details.    This is needed to access the email address.
The second change requests the "extra" information about a user, including the email address.

The first change could be avoided if, for example, the `user_show` action in CKAN 2.9 is changed to honor the `ignore_auth` value in the context.    But I am not sure if the long-term plan is to honor `ignore_auth`.   It could also be avoided if `user_show` honored the running user's administrative privileges, but the logic does not do this at the moment.

We are running this command as the user "harvest", which is configured to have administrative rights.   But the logic in `user_show` is honoring the context's 'user' field in CKAN 2.9, instead of looking at the user's privileges.   So it seems that a 'user' value must be added to the context with the current authorization logic used in `user_show`.