### PR TITLE
add recipient only if there is email

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -437,10 +437,11 @@ def harvest_get_notifications_recipients(context, data_dict):
     ).all()
 
     for sysadmin in sysadmins:
-        recipients.append({
-            'name': sysadmin.name,
-            'email': sysadmin.email
-        })
+        if sysadmin.email:
+            recipients.append({
+                'name': sysadmin.name,
+                'email': sysadmin.email
+            })
 
     # gather organization-admins
     if source.get('organization'):


### PR DESCRIPTION
This change add sysadmin to the recipient only if the sysadmin account has a non-empty email address.

This fixes the following issue:
CKAN core creates a sysadmin account using `site_id` as name, `None` as  email in code https://github.com/ckan/ckan/blob/master/ckan/logic/action/get.py#L2428-L2433,  therefore we were sending a `None` as email address down the line and eventually the mailer will generate an error.
```
python/lib/python3.7/smtplib.py", line 153, in quoteaddr                                        
if addrstring.strip().startswith('<'):                                                                                  
AttributeError: 'NoneType' object has no attribute 'strip' 
```