### PR TITLE
add index harvest_error_harvest_object_id_idx

### DIFF
--- a/ckanext/harvest/model/__init__.py
+++ b/ckanext/harvest/model/__init__.py
@@ -97,6 +97,11 @@ def setup():
             log.debug('Creating index for harvest_object_extra')
             Index("harvest_object_id_idx", harvest_object_extra_table.c.harvest_object_id).create()
 
+        index_names = [index['name'] for index in inspector.get_indexes("harvest_object_error")]
+        if "harvest_error_harvest_object_id_idx" not in index_names:
+            log.debug('Creating index for harvest_object_error')
+            Index("harvest_error_harvest_object_id_idx", harvest_object_error_table.c.harvest_object_id).create()
+
 
 class HarvestError(Exception):
     pass
@@ -398,6 +403,7 @@ def define_harvester_tables():
         Column('stage', types.UnicodeText),
         Column('line', types.Integer),
         Column('created', types.DateTime, default=datetime.datetime.utcnow),
+        Index('harvest_error_harvest_object_id_idx', 'harvest_object_id'),
     )
     # Harvest Log table
     harvest_log_table = Table(


### PR DESCRIPTION
Table `harvest_error` needs an index on column `harvest_object_id`.  Without it it takes too long to delete a harvest_object.

```
BEGIN;
EXPLAIN (analyze,buffers,timing)
DELETE FROM harvest_object WHERE id='2dce01ff-5168-400b-9698-3643a8dc3369';
ROLLBACK;
```
Before adding the index:
```
...
Trigger for constraint harvest_object_error_harvest_object_id_fkey: time=201.459 calls=1
```
After adding the index:
```
...
Trigger for constraint harvest_object_error_harvest_object_id_fkey: time=0.362 calls=1
```