### PR TITLE
added unescape for email text body to avoid encoded characters

### DIFF
--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -804,7 +804,7 @@ def prepare_error_mail(context, source_id, status):
     elif six.PY2:
         import HTMLParser
         body = HTMLParser.HTMLParser().unescape(body)
-    
+
     subject = '{} - Harvesting Job - Error Notification'\
         .format(config.get('ckan.site_title'))
 

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -3,7 +3,6 @@
 import hashlib
 import json
 import six
-import html
 
 import logging
 import datetime
@@ -799,7 +798,13 @@ def prepare_summary_mail(context, source_id, status):
 def prepare_error_mail(context, source_id, status):
     extra_vars = get_mail_extra_vars(context, source_id, status)
     body = render('emails/error_email.txt', extra_vars)
-    body = html.unescape(body)
+    if six.PY34:
+        import html
+        body = html.unescape(body)
+    elif six.PY2:
+        import HTMLParser
+        body = HTMLParser.HTMLParser().unescape(body)
+    
     subject = '{} - Harvesting Job - Error Notification'\
         .format(config.get('ckan.site_title'))
 

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import six
+import html
 
 import logging
 import datetime
@@ -798,6 +799,7 @@ def prepare_summary_mail(context, source_id, status):
 def prepare_error_mail(context, source_id, status):
     extra_vars = get_mail_extra_vars(context, source_id, status)
     body = render('emails/error_email.txt', extra_vars)
+    body = html.unescape(body)
     subject = '{} - Harvesting Job - Error Notification'\
         .format(config.get('ckan.site_title'))
 


### PR DESCRIPTION
The harvest report emails sent to users contains encoded characters, like `&#39;` and `&#34;`

This makes it hard for users to understand the error message. For example:

before 
`ERROR #1: &#39;description&#39;:&#39;&#39; is too short.`
 
after
`ERROR #1: 'description':'' is too short.`
