### PR TITLE
pick the right harvest_object_id if there are multiple

### DIFF
--- a/ckanext/harvest/logic/action/get.py
+++ b/ckanext/harvest/logic/action/get.py
@@ -267,8 +267,9 @@ def harvest_object_show(context, data_dict):
         obj = model.Session.query(HarvestObject) \
             .filter(HarvestObject.package_id == pkg.id) \
             .filter(
-            HarvestObject.current == True  # noqa: E712
-        ).first()
+                HarvestObject.current == True  # noqa: E712
+            ).order_by(HarvestObject.import_finished.desc()) \
+            .first()
     else:
         raise p.toolkit.ValidationError(
             'Please provide either an "id" or a "dataset_id" parameter')

--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -120,7 +120,10 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
 
         harvest_object = model.Session.query(HarvestObject) \
             .filter(HarvestObject.package_id == pkg_dict["id"]) \
-            .filter(HarvestObject.current == True).first() # noqa
+            .filter(
+                HarvestObject.current == True # noqa
+            ).order_by(HarvestObject.import_finished.desc()) \
+            .first()
 
         if harvest_object:
 


### PR DESCRIPTION
One package can end up with multiple **CURRENT** HarvestObject in the database for some unknown reason. We see quite a few of them in a large system. To alleviate the issue, a harmless `order_by` is added to the query to ensure the latest HarvestObject is returned.