### PR TITLE
Fix URL endpoints

### DIFF
--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -36,7 +36,7 @@ def package_list_for_source(source_id):
     It calls the package_list snippet and the pager.
     '''
     limit = 20
-    page = int(request.params.get('page', 1))
+    page = int(request.args.get('page', 1))
     fq = '+harvest_source_id:"{0}"'.format(source_id)
     search_dict = {
         'fq': fq,

--- a/ckanext/harvest/helpers.py
+++ b/ckanext/harvest/helpers.py
@@ -124,7 +124,7 @@ def link_for_harvest_object(id=None, guid=None, text=None):
         obj = logic.get_action('harvest_object_show')(context, {'id': guid, 'attr': 'guid'})
         id = obj.id
 
-    url = h.url_for('harvest.object_show', id=id)
+    url = h.url_for('harvester.object_show', id=id)
     text = text or guid or id
     link = '<a href="{url}">{text}</a>'.format(url=url, text=text)
 

--- a/ckanext/harvest/templates/source/job/read.html
+++ b/ckanext/harvest/templates/source/job/read.html
@@ -69,7 +69,7 @@
                       {{ _('Remote content') }}
                     </a>
                   {% endif %}
-                  <a href="{{ h.url_for('harvest.object_show', id=harvest_object_id) }}" class="btn btn-small">
+                  <a href="{{ h.url_for('harvester.object_show', id=harvest_object_id) }}" class="btn btn-small">
                     {{ _('Local content') }}
                   </a>
 

--- a/ckanext/harvest/templates/source/search.html
+++ b/ckanext/harvest/templates/source/search.html
@@ -31,7 +31,7 @@
           (_('Last Modified'), 'metadata_modified desc'),
           (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
         %}
-        {% snippet 'snippets/search_form.html', type='harvest', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, placeholder=_("Search harvest sources...") %}
+        {% snippet 'snippets/search_form.html', type='harvest', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.args, error=c.query_error, placeholder=_("Search harvest sources...") %}
 
         {{ h.snippet('snippets/source_list.html', sources=c.page.items, show_organization=true) }}
 

--- a/ckanext/harvest/utils.py
+++ b/ckanext/harvest/utils.py
@@ -687,7 +687,7 @@ def delete_view(id):
     try:
         context = {'model': model, 'user': tk.c.user}
 
-        context['clear_source'] = tk.request.params.get('clear',
+        context['clear_source'] = tk.request.args.get('clear',
                                                         '').lower() in (
                                                             u'true',
                                                             u'1',


### PR DESCRIPTION
This PR:
- Fixes endpoints for `object_show`: from `harvest.object_show` to `harvester.object_show`.
- Refactors deprecated `params` into `args`.