### PR TITLE
Fix asset path in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 recursive-include ckanext/harvest/templates *
-recursive-include ckanext/harvest/fanstatic_library *
+recursive-include ckanext/harvest/assets *
 recursive-include ckanext/harvest/public *
 recursive-include ckanext/harvest/i18n *

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.5.2'
+version = '1.5.3'
 
 setup(
     name='ckanext-harvest',


### PR DESCRIPTION
Currently, when doing a `pip install .`, assets folder are not properly copied.

This is a small bug fix to set a proper path for the assets folder in the MANIFEST.in