### PR TITLE
Fix a problem with data-dictization of lists to fix search-index rebuild

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ and this project adheres to `Semantic Versioning <http://semver.org/>`_
 Unreleased_
 ***********
 
+- Fix a problem with data-dictization when using sqlalchemy 1.4+
+
 ***********
 1.4.2_ - 2023-01-12
 ***********

--- a/ckanext/harvest/logic/dictization.py
+++ b/ckanext/harvest/logic/dictization.py
@@ -68,7 +68,7 @@ def harvest_job_dictize(job, context):
             .group_by(HarvestObjectError.message) \
             .order_by(text('error_count desc')) \
             .limit(context.get('error_summmary_limit', 20))
-        out['object_error_summary'] = q.all()
+        out['object_error_summary'] = _dictize_list(q.all())
         q = model.Session.query(
             HarvestGatherError.message,
             func.count(HarvestGatherError.message).label('error_count')) \
@@ -76,7 +76,7 @@ def harvest_job_dictize(job, context):
             .group_by(HarvestGatherError.message) \
             .order_by(text('error_count desc')) \
             .limit(context.get('error_summmary_limit', 20))
-        out['gather_error_summary'] = q.all()
+        out['gather_error_summary'] = _dictize_list(q.all())
     return out
 
 
@@ -144,3 +144,13 @@ def _get_source_status(source, context):
         out['last_harvest_request'] = 'Not yet harvested'
 
     return out
+
+
+def _dictize_list(db_result_list):
+    '''
+    Helper method to dictize all elements of a database result list.
+    '''
+    dictized_list = []
+    for elem in db_result_list:
+        dictized_list.append(elem._asdict())
+    return dictized_list

--- a/ckanext/harvest/logic/dictization.py
+++ b/ckanext/harvest/logic/dictization.py
@@ -68,7 +68,7 @@ def harvest_job_dictize(job, context):
             .group_by(HarvestObjectError.message) \
             .order_by(text('error_count desc')) \
             .limit(context.get('error_summmary_limit', 20))
-        out['object_error_summary'] = _dictize_list(q.all())
+        out['object_error_summary'] = harvest_error_dictize(q.all(), context)
         q = model.Session.query(
             HarvestGatherError.message,
             func.count(HarvestGatherError.message).label('error_count')) \
@@ -76,7 +76,8 @@ def harvest_job_dictize(job, context):
             .group_by(HarvestGatherError.message) \
             .order_by(text('error_count desc')) \
             .limit(context.get('error_summmary_limit', 20))
-        out['gather_error_summary'] = _dictize_list(q.all())
+        out['gather_error_summary'] = harvest_error_dictize(q.all(), context)
+
     return out
 
 
@@ -103,6 +104,13 @@ def harvest_log_dictize(obj, context):
     out = obj.as_dict()
     del out['id']
 
+    return out
+
+
+def harvest_error_dictize(obj, context):
+    out = []
+    for elem in obj:
+        out.append(elem._asdict())
     return out
 
 
@@ -144,13 +152,3 @@ def _get_source_status(source, context):
         out['last_harvest_request'] = 'Not yet harvested'
 
     return out
-
-
-def _dictize_list(db_result_list):
-    '''
-    Helper method to dictize all elements of a database result list.
-    '''
-    dictized_list = []
-    for elem in db_result_list:
-        dictized_list.append(elem._asdict())
-    return dictized_list

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -755,3 +755,33 @@ class TestActions():
         assert job['status'] == 'Running'
         assert job['gather_started'] is None
         assert 'stats' in job.keys()
+
+    def test_harvest_source_show_status(self):
+
+        source = factories.HarvestSourceObj(**SOURCE_DICT.copy())
+        job = factories.HarvestJobObj(source=source)
+        dataset = ckan_factories.Dataset()
+        obj = factories.HarvestObjectObj(
+            job=job, source=source, package_id=dataset['id'])
+
+        harvest_gather_error = harvest_model.HarvestGatherError(message="Unexpected gather error", job=job)
+        harvest_gather_error.save()
+        harvest_object_error = harvest_model.HarvestObjectError(message="Unexpected object error", object=obj)
+        harvest_object_error.save()
+
+        context = {'model': model}
+        data_dict = {'id': source.id}
+
+        source_status = get_action('harvest_source_show_status')(context, data_dict)
+
+        # verifiy that the response is dictized properly
+        json.dumps(source_status)
+
+        last_job = source_status['last_job']
+        assert last_job['source_id'] == source.id
+        assert last_job['status'] == 'New'
+        assert last_job['stats']['errored'] == 2
+        assert len(last_job['object_error_summary']) == 1
+        assert last_job['object_error_summary'][0]['message'] == harvest_object_error.message
+        assert len(last_job['gather_error_summary']) == 1
+        assert last_job['gather_error_summary'][0]['message'] == harvest_gather_error.message


### PR DESCRIPTION
Fixes #528.

The update of `sqlalchemy` from `1.3` to `1.4` caused a problem with the dictization of the data returned by the db.

https://github.com/ckan/ckanext-harvest/blob/master/ckanext/harvest/logic/dictization.py#L79 returns a list of db entries containing the errors of the harvest job. With the update of `sqlalchemy` the the return type of the list elements has changed from `sqlalchemy.util._collections.result` to `sqlalchemy.engine.row.Row`. The new type cannot be reliably dictized the way we did it so far. Therefore we made sure the elements are dictized.