### PR TITLE
Update version to 1.5.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,67 @@ The format is based on `Keep a Changelog <http://keepachangelog.com>`_
 and this project adheres to `Semantic Versioning <http://semver.org/>`_
 
 ***********
-Unreleased_
+1.5.5_ - 2023-06-05
 ***********
 
-- Fix a problem with data-dictization when using sqlalchemy 1.4+
+Fixed
+-------
+
+- Fix display of harvest job errors #533
+
+***********
+1.5.4_ - 2023-05-23
+***********
+
+Fixed
+-------
+
+- Fix a problem with data-dictization when using sqlalchemy 1.4+ #529
+
+***********
+1.5.3_ - 2023-04-03
+***********
+
+Fixed
+-------
+
+- Fix asset path in MANIFEST.in #525
+
+***********
+1.5.2_ - 2023-03-28
+***********
+
+Fixed
+-------
+
+- Fix URL endpoints: from ``harvest.object_show`` to ``harvester.object_show`` #524
+
+***********
+1.5.1_ - 2023-03-22
+***********
+
+Fixed
+-------
+
+- Fix ``url_for`` routing to point to harvester blueprint #523
+
+***********
+1.5.0_ - 2023-03-16
+***********
+
+Changed
+-------
+
+- Added unescape for email text body to avoid encoded characters #517
+- Pick the right harvest_object_id if there are multiple #519
+- Do not duplicate harvest_extras if exist in root schema #521
+- Use 403 when actions are forbidden, not 401 #522
+- Drop support old versions #520
+
+Breaking Changes
+-------
+- ``h.bootstrap_version()`` no longer exist since it is no longer needed to inject CSS classes
+- Support for old Pylon's route syntax has been removed. Example: calling ``url_for("harvest_read")`` will no longer work. URLs for ``ckanext-harvest`` needs to respect Flask's syntax: ``url_for("harvest.read")``, etc
 
 ***********
 1.4.2_ - 2023-01-12
@@ -347,7 +404,18 @@ Categories
 - ``Fixed`` for any bug fixes.
 - ``Security`` to invite users to upgrade in case of vulnerabilities.
 
-.. _Unreleased: https://github.com/ckan/ckanext-harvest/compare/v1.3.2...HEAD
+.. _Unreleased: https://github.com/ckan/ckanext-harvest/compare/v1.5.5...HEAD
+.. _1.5.5: https://github.com/ckan/ckanext-harvest/compare/v1.5.4...v1.5.5
+.. _1.5.4: https://github.com/ckan/ckanext-harvest/compare/v1.5.3...v1.5.4
+.. _1.5.3: https://github.com/ckan/ckanext-harvest/compare/v1.5.2...v1.5.3
+.. _1.5.2: https://github.com/ckan/ckanext-harvest/compare/v1.5.1...v1.5.2
+.. _1.5.1: https://github.com/ckan/ckanext-harvest/compare/v1.5.0...v1.5.1
+.. _1.5.0: https://github.com/ckan/ckanext-harvest/compare/v1.4.2...v1.5.0
+.. _1.4.2: https://github.com/ckan/ckanext-harvest/compare/v1.4.1...v1.4.2
+.. _1.4.1: https://github.com/ckan/ckanext-harvest/compare/v1.4.0...v1.4.1
+.. _1.4.0: https://github.com/ckan/ckanext-harvest/compare/v1.3.4...v1.4.0
+.. _1.3.4: https://github.com/ckan/ckanext-harvest/compare/v1.3.3...v1.3.4
+.. _1.3.3: https://github.com/ckan/ckanext-harvest/compare/v1.3.2...v1.3.3
 .. _1.3.2: https://github.com/ckan/ckanext-harvest/compare/v1.3.1...v1.3.2
 .. _1.3.1: https://github.com/ckan/ckanext-harvest/compare/v1.3.0...v1.3.1
 .. _1.3.0: https://github.com/ckan/ckanext-harvest/compare/v1.2.1...v1.3.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.5.4'
+version = '1.5.5'
 
 setup(
     name='ckanext-harvest',


### PR DESCRIPTION
Since the last version had still a bug in displaying the last job error summary we would like to release a new version `1.5.5`. 
