### PR TITLE
Use tuples for dictization of harvest job errors

### DIFF
--- a/ckanext/harvest/templates/snippets/job_error_summary.html
+++ b/ckanext/harvest/templates/snippets/job_error_summary.html
@@ -1,7 +1,7 @@
 {#
 Displays a table with a summary of the most common errors for a job
 
-error_summary        - List of tuples with (message, count)
+error_summary        - List of dicts with message and error_count
 
 Example:
 
@@ -22,8 +22,8 @@ Example:
   <tbody>
   {% for error in summary %}
     <tr>
-      <td class="count">{{ error[1] }}</td>
-      <td>{{ error[0] }}</td>
+      <td class="count">{{ error["error_count"] }}</td>
+      <td>{{ error["message"] }}</td>
     </tr>
   {% endfor %}
    </tbody>

--- a/ckanext/harvest/tests/test_action.py
+++ b/ckanext/harvest/tests/test_action.py
@@ -783,5 +783,7 @@ class TestActions():
         assert last_job['stats']['errored'] == 2
         assert len(last_job['object_error_summary']) == 1
         assert last_job['object_error_summary'][0]['message'] == harvest_object_error.message
+        assert last_job['object_error_summary'][0]['error_count'] == 1
         assert len(last_job['gather_error_summary']) == 1
         assert last_job['gather_error_summary'][0]['message'] == harvest_gather_error.message
+        assert last_job['gather_error_summary'][0]['error_count'] == 1


### PR DESCRIPTION
In #529 we changed the dictization of harvest errors. While this solves the problem #528 it causes a problem with displaying the error messages in the job overview.
Therefore we would fix this by using a tuple to restore the old behavior. 

**Details**
Since the update to `sqlalchemy 1.4.x` the harvest error objects returned by the database in https://github.com/ckan/ckanext-harvest/blob/master/ckanext/harvest/logic/dictization.py#L79 are no longer serializable which causes commands like `harvester reindex` or `harvester clearsource_history` to fail if there are any harvest jobs with errors. In #529 these harvest error objects are transformed into a dict to fix this problem. 
By doing so this data can no longer be accessed by index but this is expected by the HTML template (https://github.com/ckan/ckanext-harvest/blob/master/ckanext/harvest/templates/snippets/job_error_summary.html) and potentially by further CKAN extensions.
So our proposed solution would be to use a tuple for the data to regain the old behavior and still fix the serialization problems.