### PR TITLE
Remove CKAN 2.9 support and update to v1.6.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,6 @@ jobs:
             ckan-image: "ckan/ckan-dev:2.11-py3.10"
           - ckan-version: "2.10"
             ckan-image: "ckan/ckan-dev:2.10-py3.10"
-          - ckan-version: "2.9"
-            ckan-image: "ckan/ckan-dev:2.9-py3.9"
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
-        pip install -e .
+        pip install .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
     - name: Install requirements (2.9)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,10 +59,6 @@ jobs:
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
-    - name: Install requirements (2.9)
-      run: |
-        pip install -U pytest-rerunfailures
-      if: ${{ matrix.ckan-version == '2.9' }}
     - name: Setup extension (CKAN >= 2.9)
       run: |
         ckan -c test.ini db init

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         pip install -r requirements.txt
         pip install -r dev-requirements.txt
-        pip install .
+        pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
     - name: Install requirements (2.9)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <http://keepachangelog.com>`_
 and this project adheres to `Semantic Versioning <http://semver.org/>`_
 
+***********
+1.6.1_ - 2025-01-14
+***********
+
+Changed
+_______
+
+- CKAN 2.9 is not longer maintained #559
+
+Fixed
+-------
+- Update manifest to include alembic configuration #558
+
 
 ***********
 1.6.0_ - 2024-10-31

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 ckanext-harvest - Remote harvesting extension
 =============================================
 
-.. image:: https://github.com/ckan/ckanext-harvest/workflows/Tests/badge.svg?branch=master
+.. image:: https://github.com/ckan/ckanext-harvest/actions/workflows/test.yml/badge.svg
     :target: https://github.com/ckan/ckanext-harvest/actions
 
 This extension provides a common harvesting framework for ckan extensions
@@ -12,9 +12,8 @@ and adds a CLI and a WUI to CKAN to manage harvesting sources and jobs.
 Installation
 ============
 
-This extension requires CKAN v2.0 or later on both the CKAN it is installed
-into and the CKANs it harvests. However you are unlikely to encounter a CKAN
-running a version lower than 2.0.
+This extension requires CKAN 2.10+ to run. However, it can harvest other CKAN instances running
+version 2.0+.
 
 1. The harvest extension can use two different backends. You can choose whichever
    you prefer depending on your needs, but Redis has been found to be more stable

--- a/README.rst
+++ b/README.rst
@@ -912,7 +912,7 @@ To create a new release, follow the following steps:
 
 * Determine new release number based on the rules of `semantic versioning <http://semver.org>`_
 * Update the CHANGELOG, especially the link for the "Unreleased" section
-* Update the version number in `setup.py`
+* Update the version number in `pyproject.toml`
 * Create a new release on GitHub and add the CHANGELOG of this release as release notes
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ckanext-harvest"
-version = "1.6.0"
+version = "1.6.1"
 description = "Harvesting interface plugin for CKAN, plus harvester for other CKAN sites"
 authors = [
     {name = "Adrià Mercader", email = "amercadero@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: GNU Affero General Public License v3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR:
 - Removes the CKAN 2.9 tests since we are no longer maintaining it.
 - Bumps the version to v1.6.1 to include latest fixes.