### PR TITLE
drop temp table package_ids_to_delete

### DIFF
--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -125,6 +125,7 @@ def harvest_source_clear(context, data_dict):
             WHERE harvest_source_id = '{harvest_source_id}');"""
 
     sql += """
+        DROP TABLE IF EXISTS package_ids_to_delete;
         CREATE TEMP TABLE package_ids_to_delete AS (
             SELECT id FROM package WHERE state = 'to_delete');
         """

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -126,7 +126,7 @@ def harvest_source_clear(context, data_dict):
 
     sql += """
         DROP TABLE IF EXISTS package_ids_to_delete;
-        CREATE TEMP TABLE package_ids_to_delete AS (
+        CREATE TEMP TABLE package_ids_to_delete ON COMMIT DROP AS (
             SELECT id FROM package WHERE state = 'to_delete');
         """
 


### PR DESCRIPTION
For https://github.com/ckan/ckanext-harvest/issues/565.
This change is to avoid error `relation "package_ids_to_delete" already exists`

This error is happening because you're trying to create a temporary table that already exists in your current session.
We have three ways to fix it:
- `DROP TABLE IF EXISTS package_ids_to_delete;`
- `CREATE TEMP TABLE IF NOT EXISTS package_ids_to_delete AS (...)`
- `CREATE TEMP TABLE package_ids_to_delete ON COMMIT DROP AS (...)`

The first one is chosen since it is more clean and straightforward. 